### PR TITLE
feat: noindex login/settings/internal/og-card

### DIFF
--- a/apps/www/src/routes/internal.tsx
+++ b/apps/www/src/routes/internal.tsx
@@ -33,6 +33,9 @@ const Route = createFileRoute("/internal")({
       throw error;
     }
   },
+  head: () => ({
+    meta: [{ content: "noindex, follow", name: "robots" }],
+  }),
   component: InternalPage,
   notFoundComponent: NotFoundPage,
 });

--- a/apps/www/src/routes/login.tsx
+++ b/apps/www/src/routes/login.tsx
@@ -15,6 +15,9 @@ const loginSearchSchema = z.object({
 
 const Route = createFileRoute("/login")({
   validateSearch: loginSearchSchema,
+  head: () => ({
+    meta: [{ content: "noindex, follow", name: "robots" }],
+  }),
   component: LoginPage,
 });
 

--- a/apps/www/src/routes/og-card/$login.tsx
+++ b/apps/www/src/routes/og-card/$login.tsx
@@ -15,6 +15,9 @@ const Route = createFileRoute("/og-card/$login")({
       data,
     };
   },
+  head: () => ({
+    meta: [{ content: "noindex", name: "robots" }],
+  }),
   component: OgCardPage,
 });
 

--- a/apps/www/src/routes/settings.tsx
+++ b/apps/www/src/routes/settings.tsx
@@ -32,6 +32,9 @@ const Route = createFileRoute("/settings")({
       throw error;
     }
   },
+  head: () => ({
+    meta: [{ content: "noindex, follow", name: "robots" }],
+  }),
   component: SettingsPage,
 });
 


### PR DESCRIPTION
## What

Adds a `robots` noindex directive via route `head()` meta to non-content utility pages:

- `routes/login.tsx` — `noindex, follow` (head() added; loader/redirect untouched)
- `routes/settings.tsx` — `noindex, follow`
- `routes/internal.tsx` — `noindex, follow`
- `routes/og-card/$login.tsx` — `noindex` (HeadContent still renders even though Nav/Footer/Scripts are gated on isOgCard)

## Why

The SEO audit flagged these as low-value, non-content utility/auth pages and a raw OG-card render that should be kept out of the search index. Adding `noindex` prevents crawlers from indexing them while `follow` lets link equity flow on the auth/utility pages.

## Notes

- Build-validated (typecheck + build pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: `routes/login.tsx`, `routes/settings.tsx`, `routes/internal.tsx`, `routes/og-card/$login.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `noindex` robots meta tags to login, settings, internal, and og-card routes
> Prevents search engines from indexing the `/login`, `/settings`, `/internal`, and `/og-card/:login` routes by adding a `robots` meta tag to each route's document head. The first three use `noindex, follow`; the og-card route uses `noindex` only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d14efc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->