### PR TITLE
feat: link privacy & terms from the footer

### DIFF
--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 
 const GITHUB_REPO = "851-labs/tokenmaxxing";
 const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
@@ -37,7 +38,7 @@ function Footer() {
   const stars = useGithubStars();
 
   return (
-    <footer className="mx-4 mb-16 max-w-5xl border-x border-border lg:mx-auto -mt-px grid grid-cols-2 gap-px border-y bg-border font-mono sm:grid-cols-4">
+    <footer className="mx-4 mb-16 max-w-5xl border-x border-border lg:mx-auto -mt-px grid grid-cols-3 gap-px border-y bg-border font-mono sm:grid-cols-6">
       <FooterLink href={GITHUB_URL}>
         GitHub
         {stars.data === undefined ? null : (
@@ -47,20 +48,29 @@ function Footer() {
       <FooterLink href={LINKS.changelog}>Changelog</FooterLink>
       <FooterLink href={LINKS.discord}>Discord</FooterLink>
       <FooterLink href={LINKS.x}>X</FooterLink>
+      <FooterInternalLink to="/privacy">Privacy</FooterInternalLink>
+      <FooterInternalLink to="/terms">Terms</FooterInternalLink>
     </footer>
   );
 }
 
+const footerCellClassName =
+  "flex items-center justify-center gap-1.5 bg-background py-6 text-sm text-muted-foreground transition-colors hover:text-foreground hover:underline";
+
 function FooterLink({ children, href }: { children: ReactNode; href: string }) {
   return (
-    <a
-      className="flex items-center justify-center gap-1.5 bg-background py-6 text-sm text-muted-foreground transition-colors hover:text-foreground hover:underline"
-      href={href}
-      rel="noreferrer"
-      target="_blank"
-    >
+    <a className={footerCellClassName} href={href} rel="noreferrer" target="_blank">
       {children}
     </a>
+  );
+}
+
+/** Same-origin, crawlable footer link (no target=_blank). */
+function FooterInternalLink({ children, to }: { children: ReactNode; to: string }) {
+  return (
+    <Link className={footerCellClassName} to={to}>
+      {children}
+    </Link>
   );
 }
 


### PR DESCRIPTION
## What & why

The footer previously linked only to external destinations (GitHub, Changelog, Discord, X) via `target="_blank"` anchors, leaving the existing `/privacy` and `/terms` pages without any crawlable, same-origin internal links. The SEO audit flagged these legal pages as orphaned (not reachable from a site-wide navigation surface), which hurts their discoverability/indexing.

This PR adds two internal, crawlable footer links to `/privacy` and `/terms` using `<Link>` from `@tanstack/react-router` (no `target="_blank"`), styled identically to the existing footer cells via a shared `footerCellClassName`. The grid was widened from 2/4 columns to 3/6 columns so all six cells fit cleanly. The existing GitHub/Changelog/Discord/X links are unchanged.

## Files touched
- `apps/www/src/components/footer.tsx`

## Notes
- Build-validated (`bun run typecheck` + `bun run build` both pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: `apps/www/src/components/footer.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Privacy and Terms links to the footer
> Adds two internal footer links pointing to `/privacy` and `/terms` using a new `FooterInternalLink` component that uses TanStack Router's `Link` for client-side navigation. The footer grid expands from 2 to 3 columns on base and 4 to 6 on small screens to accommodate the new links. A shared `footerCellClassName` constant is extracted to keep styling consistent across internal and external footer links.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b7f365.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->