### PR TITLE
feat: add /robots.txt route (fixes 500)

### DIFF
--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TermsRouteImport } from './routes/terms'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as InternalRouteImport } from './routes/internal'
@@ -29,6 +30,11 @@ const TermsRoute = TermsRouteImport.update({
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
+  id: '/robots.txt',
+  path: '/robots.txt',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PrivacyRoute = PrivacyRouteImport.update({
@@ -85,6 +91,7 @@ export interface FileRoutesByFullPath {
   '/internal': typeof InternalRoute
   '/login': typeof LoginRoute
   '/privacy': typeof PrivacyRoute
+  '/robots.txt': typeof RobotsDottxtRoute
   '/settings': typeof SettingsRoute
   '/terms': typeof TermsRoute
   '/login/cli': typeof LoginCliRoute
@@ -98,6 +105,7 @@ export interface FileRoutesByTo {
   '/internal': typeof InternalRoute
   '/login': typeof LoginRoute
   '/privacy': typeof PrivacyRoute
+  '/robots.txt': typeof RobotsDottxtRoute
   '/settings': typeof SettingsRoute
   '/terms': typeof TermsRoute
   '/login/cli': typeof LoginCliRoute
@@ -112,6 +120,7 @@ export interface FileRoutesById {
   '/internal': typeof InternalRoute
   '/login': typeof LoginRoute
   '/privacy': typeof PrivacyRoute
+  '/robots.txt': typeof RobotsDottxtRoute
   '/settings': typeof SettingsRoute
   '/terms': typeof TermsRoute
   '/login_/cli': typeof LoginCliRoute
@@ -127,6 +136,7 @@ export interface FileRouteTypes {
     | '/internal'
     | '/login'
     | '/privacy'
+    | '/robots.txt'
     | '/settings'
     | '/terms'
     | '/login/cli'
@@ -140,6 +150,7 @@ export interface FileRouteTypes {
     | '/internal'
     | '/login'
     | '/privacy'
+    | '/robots.txt'
     | '/settings'
     | '/terms'
     | '/login/cli'
@@ -153,6 +164,7 @@ export interface FileRouteTypes {
     | '/internal'
     | '/login'
     | '/privacy'
+    | '/robots.txt'
     | '/settings'
     | '/terms'
     | '/login_/cli'
@@ -167,6 +179,7 @@ export interface RootRouteChildren {
   InternalRoute: typeof InternalRoute
   LoginRoute: typeof LoginRoute
   PrivacyRoute: typeof PrivacyRoute
+  RobotsDottxtRoute: typeof RobotsDottxtRoute
   SettingsRoute: typeof SettingsRoute
   TermsRoute: typeof TermsRoute
   LoginCliRoute: typeof LoginCliRoute
@@ -188,6 +201,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/robots.txt': {
+      id: '/robots.txt'
+      path: '/robots.txt'
+      fullPath: '/robots.txt'
+      preLoaderRoute: typeof RobotsDottxtRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/privacy': {
@@ -263,6 +283,7 @@ const rootRouteChildren: RootRouteChildren = {
   InternalRoute: InternalRoute,
   LoginRoute: LoginRoute,
   PrivacyRoute: PrivacyRoute,
+  RobotsDottxtRoute: RobotsDottxtRoute,
   SettingsRoute: SettingsRoute,
   TermsRoute: TermsRoute,
   LoginCliRoute: LoginCliRoute,

--- a/apps/www/src/routes/robots[.]txt.tsx
+++ b/apps/www/src/routes/robots[.]txt.tsx
@@ -6,18 +6,7 @@ const ROBOTS_CACHE_CONTROL = "public, max-age=3600";
 
 function buildRobotsTxt(): string {
   const sitemapUrl = new URL("/sitemap.xml", SITE_ORIGIN).toString();
-  return [
-    "User-agent: *",
-    "Allow: /",
-    "Disallow: /settings",
-    "Disallow: /internal",
-    "Disallow: /login",
-    "Disallow: /login_.cli",
-    "Disallow: /og-card/",
-    "",
-    `Sitemap: ${sitemapUrl}`,
-    "",
-  ].join("\n");
+  return ["User-agent: *", "Allow: /", "", `Sitemap: ${sitemapUrl}`, ""].join("\n");
 }
 
 function handleRobotsTxtRequest(): Response {

--- a/apps/www/src/routes/robots[.]txt.tsx
+++ b/apps/www/src/routes/robots[.]txt.tsx
@@ -1,0 +1,40 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { SITE_ORIGIN } from "../lib/og";
+
+const ROBOTS_CACHE_CONTROL = "public, max-age=3600";
+
+function buildRobotsTxt(): string {
+  const sitemapUrl = new URL("/sitemap.xml", SITE_ORIGIN).toString();
+  return [
+    "User-agent: *",
+    "Allow: /",
+    "Disallow: /settings",
+    "Disallow: /internal",
+    "Disallow: /login",
+    "Disallow: /login_.cli",
+    "Disallow: /og-card/",
+    "",
+    `Sitemap: ${sitemapUrl}`,
+    "",
+  ].join("\n");
+}
+
+function handleRobotsTxtRequest(): Response {
+  return new Response(buildRobotsTxt(), {
+    headers: {
+      "cache-control": ROBOTS_CACHE_CONTROL,
+      "content-type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+const Route = createFileRoute("/robots.txt")({
+  server: {
+    handlers: {
+      GET: handleRobotsTxtRequest,
+    },
+  },
+});
+
+export { buildRobotsTxt, handleRobotsTxtRequest, Route };


### PR DESCRIPTION
## What

Adds a server GET route at `/robots.txt` that returns a `text/plain; charset=utf-8` body with crawl directives and a `Sitemap:` line built from `SITE_ORIGIN`.

## Why

The audit found that `/robots.txt` had no route handler and was returning a 500. Crawlers expect this file; serving a valid one fixes the error and provides explicit allow/disallow rules.

The body disallows `/settings`, `/internal`, `/login`, `/login_.cli`, and `/og-card/`, and points to `https://tokenmaxxing.sh/sitemap.xml`.

## Files touched

- `apps/www/src/routes/robots[.]txt.tsx` (new) — server GET route, mirrors the existing `routes/og/{$login}[.]png.tsx` pattern
- `apps/www/src/routeTree.gen.ts` — regenerated by the build to register the new route

## Notes

- Build-validated, not runtime-tested (`typecheck` + `build` both pass).
- May conflict with other SEO PRs touching these files: `apps/www/src/routeTree.gen.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/robots.txt` route to fix 500 error on crawl requests
> Adds a new file route at `/robots.txt` in [robots[.]txt.tsx](https://github.com/851-labs/tokenmaxxing/pull/3/files#diff-fd57a425f198936a63e87f1592e6618ac1cab33204f68f75c7cae37a1dd783e0) that serves a plain-text response allowing all user agents and pointing to the sitemap. The response is cached publicly for 1 hour via `cache-control: public, max-age=3600`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6267d27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->