### PR TITLE
feat: add self-referential canonical URLs

### DIFF
--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -54,6 +54,7 @@ const Route = createFileRoute("/$user")({
     const url = profileUrl(profile);
 
     return {
+      links: [{ rel: "canonical", href: url }],
       meta: [
         { title },
         { name: "description", content: description },

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -12,6 +12,7 @@ import { Avatar } from "../components/ui/avatar";
 import { Code } from "../components/ui/code";
 import { Tabs } from "../components/ui/tabs";
 import { cn } from "../lib/cn";
+import { SITE_ORIGIN } from "../lib/og";
 import { leaderboardQueryOptions } from "../lib/queries";
 
 const LEADERBOARD_METRIC_VALUES = ["spend", "tokens"] as const;
@@ -30,6 +31,7 @@ const DEFAULT_LEADERBOARD_SEARCH = {
 } as const satisfies LeaderboardSearch;
 
 const Route = createFileRoute("/")({
+  head: () => ({ links: [{ rel: "canonical", href: `${SITE_ORIGIN}/` }] }),
   validateSearch: leaderboardSearchSchema,
   search: {
     middlewares: [stripSearchParams<LeaderboardSearch>(DEFAULT_LEADERBOARD_SEARCH)],

--- a/apps/www/src/routes/login.tsx
+++ b/apps/www/src/routes/login.tsx
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { LOGIN_OAUTH_PROVIDERS, OAuthProviderButtons } from "../components/oauth-providers";
 import { Card } from "../components/ui/card";
+import { SITE_ORIGIN } from "../lib/og";
 
 const loginRedirectSchema = z.preprocess(
   (value) => (typeof value === "string" ? sanitizeLoginRedirectPath(value) : undefined),
@@ -14,6 +15,9 @@ const loginSearchSchema = z.object({
 });
 
 const Route = createFileRoute("/login")({
+  head: () => ({
+    links: [{ rel: "canonical", href: new URL("/login", SITE_ORIGIN).toString() }],
+  }),
   validateSearch: loginSearchSchema,
   component: LoginPage,
 });

--- a/apps/www/src/routes/privacy.tsx
+++ b/apps/www/src/routes/privacy.tsx
@@ -2,13 +2,17 @@ import { createFileRoute } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 
 import { Code } from "../components/ui/code";
+import { SITE_ORIGIN } from "../lib/og";
 
 const GITHUB_URL = "https://github.com/851-labs/tokenmaxxing";
 const DISCORD_URL = "https://discord.gg/WzX6BpfaRH";
 const CCUSAGE_URL = "https://ccusage.com/";
 
 const Route = createFileRoute("/privacy")({
-  head: () => ({ meta: [{ title: "Privacy Policy — tokenmaxxing.sh" }] }),
+  head: () => ({
+    links: [{ rel: "canonical", href: new URL("/privacy", SITE_ORIGIN).toString() }],
+    meta: [{ title: "Privacy Policy — tokenmaxxing.sh" }],
+  }),
   component: PrivacyPage,
 });
 

--- a/apps/www/src/routes/terms.tsx
+++ b/apps/www/src/routes/terms.tsx
@@ -2,12 +2,16 @@ import { createFileRoute } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 
 import { Code } from "../components/ui/code";
+import { SITE_ORIGIN } from "../lib/og";
 
 const GITHUB_URL = "https://github.com/851-labs/tokenmaxxing";
 const DISCORD_URL = "https://discord.gg/WzX6BpfaRH";
 
 const Route = createFileRoute("/terms")({
-  head: () => ({ meta: [{ title: "Terms of Service — tokenmaxxing.sh" }] }),
+  head: () => ({
+    links: [{ rel: "canonical", href: new URL("/terms", SITE_ORIGIN).toString() }],
+    meta: [{ title: "Terms of Service — tokenmaxxing.sh" }],
+  }),
   component: TermsPage,
 });
 


### PR DESCRIPTION
## What

Adds a self-referential \`<link rel="canonical">\` to each indexable page via TanStack Router's \`head().links\`:

- \`index.tsx\` — canonical \`${SITE_ORIGIN}/\` (new \`head()\`; no title set here)
- \`$user.tsx\` — canonical \`profileUrl(profile)\`, added to the populated \`loaderData\` branch of the existing \`head()\`
- \`privacy.tsx\` / \`terms.tsx\` / \`login.tsx\` — canonical for \`/privacy\`, \`/terms\`, \`/login\` (added a \`head()\` to login.tsx; preserved existing meta)

## Why

The SEO audit found these pages had no canonical URL. Without one, query-string variants (e.g. the homepage's \`?metric=\`/\`?window=\` and login's \`?redirect=\`) can be treated as distinct/duplicate URLs by crawlers, diluting indexing signals. Self-referential canonicals point each page at its clean URL.

## Files touched

- apps/www/src/routes/index.tsx
- apps/www/src/routes/\$user.tsx
- apps/www/src/routes/privacy.tsx
- apps/www/src/routes/terms.tsx
- apps/www/src/routes/login.tsx

## Notes

- Build-validated (typecheck + build pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: index.tsx, \$user.tsx, privacy.tsx, terms.tsx, login.tsx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add self-referential canonical URL tags to all routes
> Adds `<link rel="canonical">` tags to the document head for all five routes: `/`, `/login`, `/privacy`, `/terms`, and `/$user`. Each route uses `SITE_ORIGIN` to construct the full canonical URL, with the `/$user` route using the computed profile URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c654cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->