### PR TITLE
feat: page-specific meta for privacy/terms/login

### DIFF
--- a/apps/www/src/routes/login.tsx
+++ b/apps/www/src/routes/login.tsx
@@ -3,6 +3,12 @@ import { z } from "zod";
 
 import { LOGIN_OAUTH_PROVIDERS, OAuthProviderButtons } from "../components/oauth-providers";
 import { Card } from "../components/ui/card";
+import { SITE_ORIGIN } from "../lib/og";
+
+const LOGIN_TITLE = "Sign in — tokenmaxxing.sh";
+const LOGIN_DESCRIPTION =
+  "Sign in to tokenmaxxing.sh to sync your LLM agent usage and track your spot on the leaderboard.";
+const LOGIN_URL = new URL("/login", SITE_ORIGIN).toString();
 
 const loginRedirectSchema = z.preprocess(
   (value) => (typeof value === "string" ? sanitizeLoginRedirectPath(value) : undefined),
@@ -15,6 +21,15 @@ const loginSearchSchema = z.object({
 
 const Route = createFileRoute("/login")({
   validateSearch: loginSearchSchema,
+  head: () => ({
+    meta: [
+      { title: LOGIN_TITLE },
+      { content: LOGIN_DESCRIPTION, name: "description" },
+      { content: LOGIN_TITLE, property: "og:title" },
+      { content: LOGIN_DESCRIPTION, property: "og:description" },
+      { content: LOGIN_URL, property: "og:url" },
+    ],
+  }),
   component: LoginPage,
 });
 

--- a/apps/www/src/routes/privacy.tsx
+++ b/apps/www/src/routes/privacy.tsx
@@ -2,13 +2,27 @@ import { createFileRoute } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 
 import { Code } from "../components/ui/code";
+import { SITE_ORIGIN } from "../lib/og";
 
 const GITHUB_URL = "https://github.com/851-labs/tokenmaxxing";
 const DISCORD_URL = "https://discord.gg/WzX6BpfaRH";
 const CCUSAGE_URL = "https://ccusage.com/";
 
+const PRIVACY_TITLE = "Privacy Policy — tokenmaxxing.sh";
+const PRIVACY_DESCRIPTION =
+  "How tokenmaxxing handles your data: we collect only daily usage aggregates and never your prompts, code, or session content.";
+const PRIVACY_URL = new URL("/privacy", SITE_ORIGIN).toString();
+
 const Route = createFileRoute("/privacy")({
-  head: () => ({ meta: [{ title: "Privacy Policy — tokenmaxxing.sh" }] }),
+  head: () => ({
+    meta: [
+      { title: PRIVACY_TITLE },
+      { content: PRIVACY_DESCRIPTION, name: "description" },
+      { content: PRIVACY_TITLE, property: "og:title" },
+      { content: PRIVACY_DESCRIPTION, property: "og:description" },
+      { content: PRIVACY_URL, property: "og:url" },
+    ],
+  }),
   component: PrivacyPage,
 });
 

--- a/apps/www/src/routes/terms.tsx
+++ b/apps/www/src/routes/terms.tsx
@@ -2,12 +2,26 @@ import { createFileRoute } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 
 import { Code } from "../components/ui/code";
+import { SITE_ORIGIN } from "../lib/og";
 
 const GITHUB_URL = "https://github.com/851-labs/tokenmaxxing";
 const DISCORD_URL = "https://discord.gg/WzX6BpfaRH";
 
+const TERMS_TITLE = "Terms of Service — tokenmaxxing.sh";
+const TERMS_DESCRIPTION =
+  "The terms for using tokenmaxxing.sh, the public leaderboard for LLM agent usage, provided as-is and free of charge.";
+const TERMS_URL = new URL("/terms", SITE_ORIGIN).toString();
+
 const Route = createFileRoute("/terms")({
-  head: () => ({ meta: [{ title: "Terms of Service — tokenmaxxing.sh" }] }),
+  head: () => ({
+    meta: [
+      { title: TERMS_TITLE },
+      { content: TERMS_DESCRIPTION, name: "description" },
+      { content: TERMS_TITLE, property: "og:title" },
+      { content: TERMS_DESCRIPTION, property: "og:description" },
+      { content: TERMS_URL, property: "og:url" },
+    ],
+  }),
   component: TermsPage,
 });
 


### PR DESCRIPTION
## What

Gives the `/privacy`, `/terms`, and `/login` routes their own page-specific SEO metadata instead of inheriting the homepage description and Open Graph tags.

- **privacy.tsx** & **terms.tsx**: kept the existing `title`, and added `meta name=description`, `og:title`, `og:description` (matching), and a self-referencing `og:url` built with `new URL("/privacy"|"/terms", SITE_ORIGIN).toString()`.
- **login.tsx**: added a `head()` with title "Sign in — tokenmaxxing.sh", a description, matching `og:title`/`og:description`, and a self `og:url`.

## Why

Audit finding: these inner pages had no `head()` description or OG tags (login had no `head()` at all), so they all surfaced the homepage's description and OG card in search results and link unfurls. Per-page meta improves search snippets and social previews.

Canonical (`rel=canonical`) is intentionally NOT added here — a separate PR owns canonical tags.

## Files touched

- `apps/www/src/routes/privacy.tsx`
- `apps/www/src/routes/terms.tsx`
- `apps/www/src/routes/login.tsx`

Build-validated (`typecheck` + `build` both clean), not runtime-tested.

May conflict with other SEO PRs touching these files: `routes/privacy.tsx`, `routes/terms.tsx`, `routes/login.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add page-specific meta tags to login, privacy, and terms routes
> Adds title, meta description, and Open Graph tags (title, description, URL) to the `/login`, `/privacy`, and `/terms` route `head()` configurations. Each route defines its own constants for title, description, and URL constructed from `SITE_ORIGIN`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c89cd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->