### PR TITLE
feat: keyword-aligned homepage h1 and title

### DIFF
--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -29,6 +29,8 @@ const DEFAULT_LEADERBOARD_SEARCH = {
   window: "30d",
 } as const satisfies LeaderboardSearch;
 
+const HOMEPAGE_TITLE = "Token usage leaderboard for Claude Code, Codex & Cursor — tokenmaxxing.sh";
+
 const Route = createFileRoute("/")({
   validateSearch: leaderboardSearchSchema,
   search: {
@@ -38,6 +40,9 @@ const Route = createFileRoute("/")({
   loader: async ({ context, deps }) => {
     await context.queryClient.ensureQueryData(leaderboardQueryOptions(deps.metric, deps.window));
   },
+  head: () => ({
+    meta: [{ title: HOMEPAGE_TITLE }, { property: "og:title", content: HOMEPAGE_TITLE }],
+  }),
   component: LeaderboardPage,
 });
 
@@ -365,10 +370,12 @@ function HeroSection() {
   return (
     <section className="border-b border-border px-4 py-10 sm:py-14" aria-labelledby="hero-title">
       <h1 className="max-w-3xl text-2xl font-semibold tracking-tight" id="hero-title">
-        The best place to track your token usage
+        tokenmaxxing — the social leaderboard for LLM token usage
       </h1>
       <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-        Sync local agent usage, publish your profile, and climb the leaderboard.
+        tokenmaxxing is a public leaderboard for AI coding agent usage. Sync local token and spend
+        data from Claude Code, Codex, Cursor, OpenCode, and Gemini CLI, then compare your profile
+        with everyone else.
       </p>
       <div className="mt-6 max-w-3xl">
         <div className="overflow-hidden border border-border bg-muted/40">


### PR DESCRIPTION
## What

Aligns the homepage's primary on-page text with target keywords for SEO.

- Adds a route-level `head()` setting a keyword-leading `<title>` and matching `og:title`: "Token usage leaderboard for Claude Code, Codex & Cursor — tokenmaxxing.sh" (under ~60 visible chars on the keyword phrase). Does not touch `rootHead()`.
- Rewrites the hero `<h1>` (`id="hero-title"`) to carry brand + primary keyword: "tokenmaxxing — the social leaderboard for LLM token usage".
- Rewords the lead `<p>` to an entity-first definition naming the category (public leaderboard for AI coding agent usage) and supported agents (Claude Code, Codex, Cursor, OpenCode, Gemini CLI).

## Why

Per the SEO audit, the homepage h1 ("The best place to track your token usage") and document title were generic and missed the primary keywords (token usage leaderboard, the supported agent names, and the brand). Leading with the keyword phrase + entity definition improves relevance for the category queries this site targets.

## Files touched

- `apps/www/src/routes/index.tsx`

## Notes

- Only `title` + `og:title` are set here; canonical and JSON-LD are intentionally left to other SEO PRs.
- Build-validated (`bun run typecheck` + `bun run build` both pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: `apps/www/src/routes/index.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update homepage h1 copy and set page title and og:title meta tags for keyword alignment
> - Sets the document title and `og:title` meta tag to `'Token usage leaderboard for Claude Code, Codex & Cursor — tokenmaxxing.sh'` via a new `HOMEPAGE_TITLE` constant in [index.tsx](https://github.com/851-labs/tokenmaxxing/pull/7/files#diff-007e41581e10251556a76461c0a6abe7114813e0499b9573e6c9f07c762e1cce)
> - Updates the hero `<h1>` to `'tokenmaxxing — the social leaderboard for LLM token usage'` and refreshes the subtitle copy to mention Claude Code, Codex, Cursor, OpenCode, and Gemini CLI
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b6ff73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->