### PR TITLE
feat: add /llms.txt for answer engines & coding agents

### DIFF
--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as TermsRouteImport } from './routes/terms'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as InternalRouteImport } from './routes/internal'
 import { Route as DesignRouteImport } from './routes/design'
 import { Route as UserRouteImport } from './routes/$user'
@@ -39,6 +40,11 @@ const PrivacyRoute = PrivacyRouteImport.update({
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
+  id: '/llms.txt',
+  path: '/llms.txt',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InternalRoute = InternalRouteImport.update({
@@ -83,6 +89,7 @@ export interface FileRoutesByFullPath {
   '/$user': typeof UserRoute
   '/design': typeof DesignRoute
   '/internal': typeof InternalRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/login': typeof LoginRoute
   '/privacy': typeof PrivacyRoute
   '/settings': typeof SettingsRoute
@@ -96,6 +103,7 @@ export interface FileRoutesByTo {
   '/$user': typeof UserRoute
   '/design': typeof DesignRoute
   '/internal': typeof InternalRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/login': typeof LoginRoute
   '/privacy': typeof PrivacyRoute
   '/settings': typeof SettingsRoute
@@ -110,6 +118,7 @@ export interface FileRoutesById {
   '/$user': typeof UserRoute
   '/design': typeof DesignRoute
   '/internal': typeof InternalRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/login': typeof LoginRoute
   '/privacy': typeof PrivacyRoute
   '/settings': typeof SettingsRoute
@@ -125,6 +134,7 @@ export interface FileRouteTypes {
     | '/$user'
     | '/design'
     | '/internal'
+    | '/llms.txt'
     | '/login'
     | '/privacy'
     | '/settings'
@@ -138,6 +148,7 @@ export interface FileRouteTypes {
     | '/$user'
     | '/design'
     | '/internal'
+    | '/llms.txt'
     | '/login'
     | '/privacy'
     | '/settings'
@@ -151,6 +162,7 @@ export interface FileRouteTypes {
     | '/$user'
     | '/design'
     | '/internal'
+    | '/llms.txt'
     | '/login'
     | '/privacy'
     | '/settings'
@@ -165,6 +177,7 @@ export interface RootRouteChildren {
   UserRoute: typeof UserRoute
   DesignRoute: typeof DesignRoute
   InternalRoute: typeof InternalRoute
+  LlmsDottxtRoute: typeof LlmsDottxtRoute
   LoginRoute: typeof LoginRoute
   PrivacyRoute: typeof PrivacyRoute
   SettingsRoute: typeof SettingsRoute
@@ -202,6 +215,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/llms.txt': {
+      id: '/llms.txt'
+      path: '/llms.txt'
+      fullPath: '/llms.txt'
+      preLoaderRoute: typeof LlmsDottxtRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/internal': {
@@ -261,6 +281,7 @@ const rootRouteChildren: RootRouteChildren = {
   UserRoute: UserRoute,
   DesignRoute: DesignRoute,
   InternalRoute: InternalRoute,
+  LlmsDottxtRoute: LlmsDottxtRoute,
   LoginRoute: LoginRoute,
   PrivacyRoute: PrivacyRoute,
   SettingsRoute: SettingsRoute,

--- a/apps/www/src/routes/llms[.]txt.tsx
+++ b/apps/www/src/routes/llms[.]txt.tsx
@@ -1,0 +1,57 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+const SITE_URL = "https://tokenmaxxing.sh";
+const GITHUB_URL = "https://github.com/851-labs/tokenmaxxing";
+const DISCORD_URL = "https://discord.gg/WzX6BpfaRH";
+const X_URL = "https://x.com/pondorasti";
+
+/** Curated llms.txt for answer engines and coding agents. Copy is sourced from
+ * the homepage FAQ and the privacy page so it stays accurate to the product. */
+const LLMS_TXT = `# tokenmaxxing.sh
+
+> The social leaderboard for LLM coding-agent token usage. tokenmaxxing syncs your local usage from supported coding agents, turns it into daily token and spend totals, and lets you compare with other users on a public leaderboard.
+
+## How to join
+
+Install the CLI, then run the bootstrap command. Bootstrap signs you in, syncs your usage, and can set up automatic syncing.
+
+\`\`\`
+npm install -g @851-labs/tokenmaxxing
+tokenmaxxing bootstrap
+\`\`\`
+
+## Supported agents
+
+Usage is parsed locally via [ccusage](https://ccusage.com/). Only daily aggregates (date, model name, agent source, token counts, and API-equivalent cost) are uploaded — prompts, file paths, project names, and session content are never uploaded.
+
+- Claude Code
+- OpenAI Codex
+- Cursor
+- OpenCode
+- Gemini CLI
+
+## Links
+
+- [Site](${SITE_URL})
+- [Privacy](${SITE_URL}/privacy)
+- [Terms](${SITE_URL}/terms)
+- [GitHub](${GITHUB_URL})
+- [Discord](${DISCORD_URL})
+- [X](${X_URL})
+`;
+
+const Route = createFileRoute("/llms.txt")({
+  server: {
+    handlers: {
+      GET: () =>
+        new Response(LLMS_TXT, {
+          headers: {
+            "cache-control": "public, max-age=3600, stale-while-revalidate=86400",
+            "content-type": "text/markdown; charset=utf-8",
+          },
+        }),
+    },
+  },
+});
+
+export { Route };


### PR DESCRIPTION
## What

Adds a curated `/llms.txt` server route (`apps/www/src/routes/llms[.]txt.tsx`) that returns `text/markdown; charset=utf-8`. The document covers what tokenmaxxing.sh is, how to join (npm install + bootstrap), supported agents (Claude Code, OpenAI Codex, Cursor, OpenCode, Gemini CLI — parsed locally via ccusage), and key links (site, /privacy, /terms, GitHub, Discord, X).

## Why

Per the SEO audit, there was no `/llms.txt` for answer engines and coding agents to discover an accurate, machine-readable summary of the product. This gives LLM tooling a canonical, curated source instead of scraping the marketing page.

Copy is sourced from the homepage FAQ (`index.tsx`) and the privacy page so it stays accurate to the product.

## Files touched

- `apps/www/src/routes/llms[.]txt.tsx` (new)
- `apps/www/src/routeTree.gen.ts` (regenerated by build)

## Notes

- Build-validated (`bun run typecheck && bun run build` both pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: `apps/www/src/routeTree.gen.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/llms.txt` route for answer engines and coding agents
> Adds a new server-side GET handler at `/llms.txt` in [llms[.]txt.tsx](https://github.com/851-labs/tokenmaxxing/pull/8/files#diff-7a722f5fb3c7bbfa57a52c4e0d7f71db8218bc1e0dca27e02e747ad93773458a) that returns a curated markdown document describing the site. The response includes `text/markdown` content type and cache headers (`max-age=3600`, `stale-while-revalidate=86400`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 795f8f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->