### PR TITLE
feat: crawlable supported-agents text in hero

### DIFF
--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -80,6 +80,17 @@ const SUPPORTED_AGENTS = [
   { icon: <GeminiIcon />, label: "Gemini CLI" },
 ] as const;
 
+const SUPPORTED_AGENT_LABELS = SUPPORTED_AGENTS.map((agent) => agent.label);
+
+// "A, B, C, and D" — keeps the visible agent prose in sync with the icon strip.
+function formatAgentList(labels: readonly string[]) {
+  if (labels.length <= 1) {
+    return labels.join("");
+  }
+
+  return `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`;
+}
+
 const FAQ_ITEMS: { answer: ReactNode; question: string }[] = [
   {
     question: "What is tokenmaxxing?",
@@ -116,7 +127,7 @@ const FAQ_ITEMS: { answer: ReactNode; question: string }[] = [
         >
           ccusage
         </a>{" "}
-        to parse local usage from Claude Code, Codex, OpenCode, Gemini CLI, and Copilot CLI.
+        to parse local usage from {formatAgentList(SUPPORTED_AGENT_LABELS)}.
       </>
     ),
   },
@@ -429,6 +440,9 @@ function HeroSection() {
             </li>
           ))}
         </ul>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+          Works with {formatAgentList(SUPPORTED_AGENT_LABELS)} — parsed locally via ccusage.
+        </p>
       </div>
     </section>
   );

--- a/apps/www/src/routes/privacy.tsx
+++ b/apps/www/src/routes/privacy.tsx
@@ -35,8 +35,8 @@ function PrivacyPage() {
 
         <Section title="How data is sourced">
           The CLI uses <ExternalLink href={CCUSAGE_URL}>ccusage</ExternalLink> to parse usage
-          locally from supported coding agents (Claude Code, Codex, OpenCode, Gemini CLI, and
-          Copilot CLI). It only reads usage data that still exists on your computer; if an agent has
+          locally from supported coding agents (Claude Code, OpenAI Codex, Cursor, OpenCode, and
+          Gemini CLI). It only reads usage data that still exists on your computer; if an agent has
           already cleaned up its local logs, that data cannot be recovered or uploaded. You can
           preview exactly what would be sent with <Code>tokenmaxxing sync --dry-run</Code>.
         </Section>


### PR DESCRIPTION
## What

Adds a visible, crawlable prose line in the homepage hero naming the supported agents, complementing the existing icon-only strip (whose SVGs are \`aria-hidden\`):

> Works with Claude Code, OpenAI Codex, Cursor, OpenCode, and Gemini CLI — parsed locally via ccusage.

The line is derived from \`SUPPORTED_AGENTS\` via a small local \`formatAgentList\` helper so the prose always stays in sync with the icon strip. The icon strip is kept as-is.

## Why

Audit finding: the supported agents were only conveyed through \`aria-hidden\` icon SVGs, so the agent names were not crawlable as text. The audit also flagged an inconsistent agent list — \`SUPPORTED_AGENTS\` has 5 (Claude Code, OpenAI Codex, Cursor, OpenCode, Gemini CLI) while the FAQ and privacy page listed Copilot CLI and omitted Cursor. Reconciled to ONE accurate list matching the rendered icon strip and applied it consistently across the hero prose, the FAQ "Which agents" answer, and the privacy "How data is sourced" section.

## Files touched

- \`apps/www/src/routes/index.tsx\` — add \`formatAgentList\` helper + \`SUPPORTED_AGENT_LABELS\`, crawlable hero prose line, and reconcile the FAQ answer to the canonical list.
- \`apps/www/src/routes/privacy.tsx\` — reconcile the supported-agents list (drop Copilot CLI, add Cursor).

Build-validated, not runtime-tested.

May conflict with other SEO PRs touching these files: \`apps/www/src/routes/index.tsx\`, \`apps/www/src/routes/privacy.tsx\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add crawlable supported-agents text to hero section
> - Adds a visible sentence listing supported agents in the hero section, formatted with an Oxford comma using a new `formatAgentList` utility.
> - Updates the FAQ 'How is usage parsed?' answer to derive the agent list dynamically from `SUPPORTED_AGENTS` rather than a hardcoded string.
> - Updates the privacy page agent list in [privacy.tsx](https://github.com/851-labs/tokenmaxxing/pull/9/files#diff-da4d0b568a26d99e1c1f8dbc1e86b4068ea2d83c3627f19cc65aaa619c3a8aa2) to reflect current agent names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 795a1bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->