### PR TITLE
feat: add /sitemap.xml (profiles + static pages)

### DIFF
--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TermsRouteImport } from './routes/terms'
+import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LoginRouteImport } from './routes/login'
@@ -24,6 +25,11 @@ import { Route as LoginCliRouteImport } from './routes/login_.cli'
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
   path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
+  id: '/sitemap.xml',
+  path: '/sitemap.xml',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SettingsRoute = SettingsRouteImport.update({
@@ -86,6 +92,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/privacy': typeof PrivacyRoute
   '/settings': typeof SettingsRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
   '/terms': typeof TermsRoute
   '/login/cli': typeof LoginCliRoute
   '/og-card/$login': typeof OgCardLoginRoute
@@ -99,6 +106,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/privacy': typeof PrivacyRoute
   '/settings': typeof SettingsRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
   '/terms': typeof TermsRoute
   '/login/cli': typeof LoginCliRoute
   '/og-card/$login': typeof OgCardLoginRoute
@@ -113,6 +121,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/privacy': typeof PrivacyRoute
   '/settings': typeof SettingsRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
   '/terms': typeof TermsRoute
   '/login_/cli': typeof LoginCliRoute
   '/og-card/$login': typeof OgCardLoginRoute
@@ -128,6 +137,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/privacy'
     | '/settings'
+    | '/sitemap.xml'
     | '/terms'
     | '/login/cli'
     | '/og-card/$login'
@@ -141,6 +151,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/privacy'
     | '/settings'
+    | '/sitemap.xml'
     | '/terms'
     | '/login/cli'
     | '/og-card/$login'
@@ -154,6 +165,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/privacy'
     | '/settings'
+    | '/sitemap.xml'
     | '/terms'
     | '/login_/cli'
     | '/og-card/$login'
@@ -168,6 +180,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   PrivacyRoute: typeof PrivacyRoute
   SettingsRoute: typeof SettingsRoute
+  SitemapDotxmlRoute: typeof SitemapDotxmlRoute
   TermsRoute: typeof TermsRoute
   LoginCliRoute: typeof LoginCliRoute
   OgCardLoginRoute: typeof OgCardLoginRoute
@@ -181,6 +194,13 @@ declare module '@tanstack/react-router' {
       path: '/terms'
       fullPath: '/terms'
       preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sitemap.xml': {
+      id: '/sitemap.xml'
+      path: '/sitemap.xml'
+      fullPath: '/sitemap.xml'
+      preLoaderRoute: typeof SitemapDotxmlRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/settings': {
@@ -264,6 +284,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   PrivacyRoute: PrivacyRoute,
   SettingsRoute: SettingsRoute,
+  SitemapDotxmlRoute: SitemapDotxmlRoute,
   TermsRoute: TermsRoute,
   LoginCliRoute: LoginCliRoute,
   OgCardLoginRoute: OgCardLoginRoute,

--- a/apps/www/src/routes/sitemap[.]xml.tsx
+++ b/apps/www/src/routes/sitemap[.]xml.tsx
@@ -1,0 +1,81 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { runApi } from "../lib/api";
+import { SITE_ORIGIN } from "../lib/og";
+
+/**
+ * /sitemap.xml — public profile pages (sourced from the all-time leaderboard)
+ * plus the static marketing/legal routes. Authenticated, internal, and
+ * asset routes (login/settings/og/og-card) are intentionally excluded.
+ */
+
+const STATIC_PATHS = ["/", "/privacy", "/terms"] as const;
+
+const CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
+
+interface SitemapUrl {
+  loc: string;
+  lastmod?: string;
+}
+
+async function loadProfileUrls(): Promise<SitemapUrl[]> {
+  try {
+    const result = await runApi((client) =>
+      client.leaderboard.list({ query: { metric: "spend", window: "all" } }),
+    );
+
+    return result.entries.map((entry) => ({
+      loc: new URL(`/${encodeURIComponent(entry.user.login)}`, SITE_ORIGIN).toString(),
+      ...(entry.lastDate === null ? {} : { lastmod: entry.lastDate }),
+    }));
+  } catch {
+    // API failure must not break the sitemap — fall back to static URLs only.
+    return [];
+  }
+}
+
+function staticUrls(): SitemapUrl[] {
+  return STATIC_PATHS.map((path) => ({
+    loc: new URL(path, SITE_ORIGIN).toString(),
+  }));
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function renderUrl(url: SitemapUrl): string {
+  const lastmod = url.lastmod === undefined ? "" : `<lastmod>${escapeXml(url.lastmod)}</lastmod>`;
+  return `<url><loc>${escapeXml(url.loc)}</loc>${lastmod}</url>`;
+}
+
+function renderSitemap(urls: SitemapUrl[]): string {
+  const body = urls.map(renderUrl).join("");
+  return `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${body}</urlset>`;
+}
+
+async function handleSitemapRequest(): Promise<Response> {
+  const urls = [...staticUrls(), ...(await loadProfileUrls())];
+
+  return new Response(renderSitemap(urls), {
+    headers: {
+      "cache-control": CACHE_CONTROL,
+      "content-type": "application/xml; charset=utf-8",
+    },
+  });
+}
+
+const Route = createFileRoute("/sitemap.xml")({
+  server: {
+    handlers: {
+      GET: handleSitemapRequest,
+    },
+  },
+});
+
+export { handleSitemapRequest, Route };


### PR DESCRIPTION
## What & why

Adds a `/sitemap.xml` server route so search engines can discover public profile pages and the static marketing/legal routes. The SEO audit found the site exposed no sitemap, leaving profile pages undiscoverable via standard crawling.

The handler:
- Enumerates public profiles from the all-time leaderboard (`client.leaderboard.list({ query: { metric: "spend", window: "all" } })`). Each `<loc>` is built as `new URL("/" + encodeURIComponent(entry.user.login), SITE_ORIGIN)` to match `profileUrl` in `lib/og.ts`; `<lastmod>` is emitted only when `entry.lastDate` is non-null.
- Adds static `<url>` entries for `/`, `/privacy`, `/terms`. Login/settings/internal/og/og-card routes are excluded.
- Degrades gracefully: if the API call fails it still returns 200 with the static URLs.
- Responds with `content-type: application/xml; charset=utf-8` and `cache-control: public, max-age=3600, stale-while-revalidate=86400`.

## Files touched
- `apps/www/src/routes/sitemap[.]xml.tsx` (new)
- `apps/www/src/routeTree.gen.ts` (regenerated by build)

## Notes
- Build-validated, not runtime-tested.
- May conflict with other SEO PRs touching these files: `apps/www/src/routeTree.gen.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/sitemap.xml` route serving static pages and dynamic profile URLs
> - Adds a new TanStack file route at `/sitemap.xml` in [sitemap[.]xml.tsx](https://github.com/851-labs/tokenmaxxing/pull/10/files#diff-b2d10f3bfc6aca1aa5ad3971f084e7bddf05f6c92d6a9406d5a9792caaf6544e) that returns a fully-formed XML sitemap.
> - Static paths (`/`, `/privacy`, `/terms`) are always included; profile URLs are fetched from the leaderboard API and appended dynamically.
> - API failures in profile URL loading are caught silently, returning an empty list rather than failing the whole response.
> - Response includes `Content-Type: application/xml` and cache headers (`max-age=3600`, `stale-while-revalidate=86400`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b97879c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->