### PR TITLE
fix: return 404 instead of 500 for unknown paths and missing profiles

### DIFF
--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { LinkSimple } from "@phosphor-icons/react/ssr";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, notFound } from "@tanstack/react-router";
 import type { ProfileDailyResponse, ProfileDailyRow } from "@tokenmaxxing/api-contract";
 
 type DailyRow = typeof ProfileDailyRow.Type;
@@ -23,6 +23,7 @@ import { Avatar } from "../components/ui/avatar";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { Code } from "../components/ui/code";
+import { isApiError } from "../lib/api";
 import {
   OG_IMAGE_HEIGHT,
   OG_IMAGE_WIDTH,
@@ -35,12 +36,20 @@ import { profileDailyQueryOptions, profileQueryOptions } from "../lib/queries";
 
 const Route = createFileRoute("/$user")({
   loader: async ({ context, params }) => {
-    const [profile, daily] = await Promise.all([
-      context.queryClient.ensureQueryData(profileQueryOptions(params.user)),
-      context.queryClient.ensureQueryData(profileDailyQueryOptions(params.user)),
-    ]);
+    try {
+      const [profile, daily] = await Promise.all([
+        context.queryClient.ensureQueryData(profileQueryOptions(params.user)),
+        context.queryClient.ensureQueryData(profileDailyQueryOptions(params.user)),
+      ]);
 
-    return { daily, profile };
+      return { daily, profile };
+    } catch (error) {
+      if (isApiError(error, "UserNotFound")) {
+        throw notFound();
+      }
+
+      throw error;
+    }
   },
   head: ({ loaderData }) => {
     if (loaderData === undefined) {

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import {
   createRootRouteWithContext,
   HeadContent,
+  Link,
   Outlet,
   Scripts,
   useRouterState,
@@ -48,7 +49,22 @@ function rootHead() {
 const Route = createRootRouteWithContext<RouterContext>()({
   head: rootHead,
   component: RootDocument,
+  notFoundComponent: NotFoundPage,
 });
+
+function NotFoundPage() {
+  return (
+    <div className="mx-auto mt-24 max-w-sm px-4 text-center">
+      <h1 className="text-xl font-semibold tracking-tight">Page not found</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        We couldn&apos;t find the page you were looking for.
+      </p>
+      <Link className="mt-6 inline-flex text-sm font-medium underline underline-offset-4" to="/">
+        Back to tokenmaxxing.sh
+      </Link>
+    </div>
+  );
+}
 
 function RootDocument() {
   const pathname = useRouterState({ select: (state) => state.location.pathname });


### PR DESCRIPTION
## What

Unknown top-level paths and nonexistent profiles previously returned HTTP **500**: the `/$user` catch-all route's loader threw on the API `UserNotFound` error, which surfaced as an unhandled server error.

This change:
- In `routes/$user.tsx`, wraps the loader's `Promise.all` in try/catch. On `isApiError(error, "UserNotFound")` it throws `notFound()` (from `@tanstack/react-router`); any other error is rethrown unchanged. The existing `head()` `loaderData === undefined` guard is kept.
- In `routes/__root.tsx`, registers a sitewide branded `notFoundComponent` ("Page not found" with a `Link` back to `/`) on the root route, so 404s render through TanStack Start and SSR with a 404 status.

## Why

Audit finding: unknown paths / missing profiles returned 500 instead of 404, which is wrong for SEO (search engines should see a clean 404, not a server error) and for users.

## Files touched
- `apps/www/src/routes/$user.tsx`
- `apps/www/src/routes/__root.tsx`

Build-validated (`bun run typecheck && bun run build` both pass), not runtime-tested.

May conflict with other SEO PRs touching these files: `routes/$user.tsx`, `routes/__root.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return 404 instead of 500 for unknown paths and missing user profiles
> - Adds a `notFoundComponent` to the root route in [`__root.tsx`](https://github.com/851-labs/tokenmaxxing/pull/11/files#diff-9eb17af4bb2e99d1f20a633c7cb0b17bd843f182cc062813ee0ba6318b2a3c92) that renders a custom 404 page with a link back to the homepage for unmatched paths.
> - Wraps the profile data fetch in [`$user.tsx`](https://github.com/851-labs/tokenmaxxing/pull/11/files#diff-b144edf0ecacfa322bf976b90adabd811b06a96b18a9e2474520c75881814e20) in a try/catch; throws `notFound()` when the API returns a `UserNotFound` error, otherwise rethrows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 178142d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->