### PR TITLE
fix: leaderboard table caption and th scope

### DIFF
--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -288,14 +288,29 @@ function LeaderboardPage() {
             </p>
           ) : (
             <table className="w-full text-sm">
+              <caption className="sr-only">
+                Leaderboard of top users by LLM token spend and usage
+              </caption>
               <thead>
                 <tr className="border-b border-border bg-muted/50 text-left text-xs uppercase tracking-wider text-muted-foreground">
-                  <th className="w-12 p-3 font-medium">#</th>
-                  <th className="p-3 font-medium">User</th>
-                  <th className="p-3 text-right font-medium">Spend</th>
-                  <th className="p-3 text-right font-medium">Tokens</th>
-                  <th className="hidden p-3 text-right font-medium sm:table-cell">Active days</th>
-                  <th className="hidden p-3 text-right font-medium sm:table-cell">Last active</th>
+                  <th className="w-12 p-3 font-medium" scope="col">
+                    #
+                  </th>
+                  <th className="p-3 font-medium" scope="col">
+                    User
+                  </th>
+                  <th className="p-3 text-right font-medium" scope="col">
+                    Spend
+                  </th>
+                  <th className="p-3 text-right font-medium" scope="col">
+                    Tokens
+                  </th>
+                  <th className="hidden p-3 text-right font-medium sm:table-cell" scope="col">
+                    Active days
+                  </th>
+                  <th className="hidden p-3 text-right font-medium sm:table-cell" scope="col">
+                    Last active
+                  </th>
                 </tr>
               </thead>
               <tbody>


### PR DESCRIPTION
## What

Improve accessibility of the homepage leaderboard `<table>` in `apps/www/src/routes/index.tsx`:

- Add `scope="col"` to the six column header `<th>` cells so assistive technology can correctly associate header cells with their columns.
- Add a visually-hidden `<caption className="sr-only">Leaderboard of top users by LLM token spend and usage</caption>` so screen-reader users get a descriptive table name.

No visual change (`sr-only` is built into Tailwind v4).

## Why

Audit finding: the leaderboard table had no caption and its header cells lacked `scope`, so screen readers could not announce the table's purpose or reliably map data cells to their headers.

## Files touched

- `apps/www/src/routes/index.tsx`

Build-validated (typecheck + build pass), not runtime-tested.

May conflict with other SEO PRs touching these files: `apps/www/src/routes/index.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix leaderboard table accessibility with caption and `scope` attributes on header cells
> Adds a visually hidden `<caption>` and `scope="col"` attributes to all `<th>` elements in the leaderboard table in [index.tsx](https://github.com/851-labs/tokenmaxxing/pull/12/files#diff-007e41581e10251556a76461c0a6abe7114813e0499b9573e6c9f07c762e1cce). This improves screen reader semantics without changing the visual layout or data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c6fabc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->