### PR TITLE
feat: show profile activity recency

### DIFF
--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -78,19 +78,61 @@ function formatCount(value: number): string {
   return countFormatter.format(value);
 }
 
+const activityDateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
+
+function formatActivityDate(date: string): string {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return date;
+  }
+
+  return activityDateFormatter.format(parsed);
+}
+
+function activityRecencyLabel(stats: {
+  activeDays: number;
+  firstDate: string | null;
+  lastDate: string | null;
+}): string | null {
+  if (stats.activeDays === 0 || stats.firstDate === null || stats.lastDate === null) {
+    return null;
+  }
+
+  const days = `${formatCount(stats.activeDays)} active ${stats.activeDays === 1 ? "day" : "days"}`;
+  const range =
+    stats.firstDate === stats.lastDate
+      ? formatActivityDate(stats.firstDate)
+      : `${formatActivityDate(stats.firstDate)} – ${formatActivityDate(stats.lastDate)}`;
+
+  return `Active ${range} · ${days}`;
+}
+
 function ProfilePage() {
   const { user } = Route.useParams();
   const { data: profile } = useSuspenseQuery(profileQueryOptions(user));
   const { data: daily } = useSuspenseQuery(profileDailyQueryOptions(user));
   const { stats } = profile;
   const owner = profile.user;
+  const activityRecency = activityRecencyLabel(stats);
 
   return (
     <>
       <header className="flex items-center justify-between gap-4 px-4 py-8">
         <div className="flex min-w-0 items-center gap-4">
           <Avatar size={56} src={owner.avatarUrl} />
-          <h1 className="min-w-0 truncate text-2xl font-semibold tracking-tight">{owner.login}</h1>
+          <div className="min-w-0">
+            <h1 className="min-w-0 truncate text-2xl font-semibold tracking-tight">
+              {owner.login}
+            </h1>
+            {activityRecency !== null ? (
+              <p className="truncate text-sm text-muted-foreground">{activityRecency}</p>
+            ) : null}
+          </div>
         </div>
         <ProfileShareButton url={profileUrl(profile)} />
       </header>


### PR DESCRIPTION
## What

Adds a small muted line under the profile login in the `ProfilePage` header showing activity range and recency derived from `profile.stats`, e.g. `Active 1 Mar 2026 – 14 Jun 2026 · 87 active days`.

## Why

Audit finding: the profile header surfaced the login but gave no at-a-glance sense of how recent or extensive a user's usage is. Showing the active date range plus active-day count communicates freshness and depth of activity without requiring the visitor to scan the charts.

## Details

- New local helpers in `routes/$user.tsx`: `formatActivityDate` (UTC-stable `Intl.DateTimeFormat`) and `activityRecencyLabel`.
- Guards: renders nothing when `activeDays === 0` or when `firstDate`/`lastDate` are null. Collapses to a single date when first and last match. Pluralizes "day"/"days".
- `dateModified` JSON-LD is intentionally out of scope (owned by another PR).

## Files touched

- `apps/www/src/routes/$user.tsx`

Build-validated (`bun run typecheck && bun run build` both exit 0), not runtime-tested.

May conflict with other SEO PRs touching these files: `apps/www/src/routes/$user.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show activity recency in profile header
> Adds an activity summary line beneath the username on profile pages. The line displays "Active {date or range} · {N active day(s)}" derived from the user's `activeDays`, `firstDate`, and `lastDate` stats, and is omitted when stats are unavailable. Date formatting uses `Intl.DateTimeFormat` in UTC to avoid timezone shifts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a32ced.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->