### PR TITLE
fix: stabilize footer GitHub stars (CLS/caching)

### DIFF
--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -29,6 +29,8 @@ function useGithubStars() {
     },
     queryKey: ["github-stars", GITHUB_REPO],
     staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60 * 24,
+    refetchOnWindowFocus: false,
   });
 }
 
@@ -40,9 +42,10 @@ function Footer() {
     <footer className="mx-4 mb-16 max-w-5xl border-x border-border lg:mx-auto -mt-px grid grid-cols-2 gap-px border-y bg-border font-mono sm:grid-cols-4">
       <FooterLink href={GITHUB_URL}>
         GitHub
-        {stars.data === undefined ? null : (
-          <span className="text-muted-foreground">[{starsFormatter.format(stars.data)}]</span>
-        )}
+        {/* Reserve a fixed-width slot so the badge never shifts layout when it loads. */}
+        <span className="inline-block w-10 text-left text-muted-foreground">
+          {stars.data === undefined ? null : `[${starsFormatter.format(stars.data)}]`}
+        </span>
       </FooterLink>
       <FooterLink href={LINKS.changelog}>Changelog</FooterLink>
       <FooterLink href={LINKS.discord}>Discord</FooterLink>


### PR DESCRIPTION
## What

The footer's GitHub stars badge is fetched client-side via `useGithubStars` on every page. This change makes two WWW-safe improvements (no new server/API fetch — keeping the unauthenticated call client-side avoids worsening GitHub rate-limiting through a single egress IP):

- **Reserve stable space for the badge**: the `[stars]` count is now rendered inside a fixed-width (`w-10`) inline slot that is always present, so the footer no longer shifts layout (CLS) when the count loads.
- **Tighten the query**: keep `staleTime` 1h, add `refetchOnWindowFocus: false` and a 24h `gcTime` so the count is not refetched unnecessarily. Graceful failure (count omitted on error) is preserved.

## Why

Per the SEO/perf audit, the footer stars caused avoidable layout shift on load and the query refetched more than necessary.

## Files touched

- `apps/www/src/components/footer.tsx`

Build-validated, not runtime-tested.

May conflict with other SEO PRs touching these files: `apps/www/src/components/footer.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix footer GitHub stars layout shift by reserving fixed-width slot and extending cache
> - Reserves a fixed-width inline-block span for the star count in [footer.tsx](https://github.com/851-labs/tokenmaxxing/pull/14/files#diff-57f2fdd0d117eb32a4f7f280d223e3300b80c0b1b8ebc03bb3cd9033e0f82db5) so the layout doesn't shift when data loads (CLS fix).
> - Sets `gcTime` to 24 hours and disables `refetchOnWindowFocus` in the `useGithubStars` hook to reduce redundant fetches and retain cached data longer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 122387d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->