### PR TITLE
fix: descriptive alt text on profile/leaderboard avatars

### DIFF
--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -89,7 +89,7 @@ function ProfilePage() {
     <>
       <header className="flex items-center justify-between gap-4 px-4 py-8">
         <div className="flex min-w-0 items-center gap-4">
-          <Avatar size={56} src={owner.avatarUrl} />
+          <Avatar alt={`${owner.login} avatar`} size={56} src={owner.avatarUrl} />
           <h1 className="min-w-0 truncate text-2xl font-semibold tracking-tight">{owner.login}</h1>
         </div>
         <ProfileShareButton url={profileUrl(profile)} />

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -311,7 +311,11 @@ function LeaderboardPage() {
                         params={{ user: entry.user.login }}
                         to="/$user"
                       >
-                        <Avatar size={24} src={entry.user.avatarUrl} />
+                        <Avatar
+                          alt={`${entry.user.login} avatar`}
+                          size={24}
+                          src={entry.user.avatarUrl}
+                        />
                         {entry.user.login}
                       </Link>
                     </td>


### PR DESCRIPTION
## What

Pass meaningful `alt` text to content avatars so screen readers and SEO crawlers can identify them. The `Avatar` component already forwards `alt` to its `<img>` but defaults to `alt=""`, leaving content avatars unlabeled.

- `routes/index.tsx`: leaderboard row avatar (size 24) now uses `alt={\`\${entry.user.login} avatar\`}`.
- `routes/$user.tsx`: profile header avatar (size 56) now uses `alt={\`\${owner.login} avatar\`}`.

Decorative avatars (og-card) are intentionally left empty.

## Why

Audit finding: content avatars had empty alt text, which hurts accessibility and image SEO. Descriptive alt text identifies the user each avatar represents.

## Files touched

- `apps/www/src/routes/index.tsx`
- `apps/www/src/routes/$user.tsx`

Build-validated, not runtime-tested.

May conflict with other SEO PRs touching these files: `routes/index.tsx`, `routes/$user.tsx`, `components/ui/avatar.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add descriptive alt text to avatars on profile and leaderboard pages
> Adds an `alt` prop to the `Avatar` component in [\$user.tsx](https://github.com/851-labs/tokenmaxxing/pull/15/files#diff-b144edf0ecacfa322bf976b90adabd811b06a96b18a9e2474520c75881814e20) and [index.tsx](https://github.com/851-labs/tokenmaxxing/pull/15/files#diff-007e41581e10251556a76461c0a6abe7114813e0499b9573e6c9f07c762e1cce), set to `"${login} avatar"`. This improves accessibility for screen readers on both the profile header and leaderboard table rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe9d7f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->