### PR TITLE
feat: add skip-to-content link

### DIFF
--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -60,8 +60,19 @@ function RootDocument() {
         <HeadContent />
       </head>
       <body className="min-h-screen antialiased">
+        {isOgCard ? null : (
+          <a
+            href="#content"
+            className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:border focus:border-border focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            Skip to content
+          </a>
+        )}
         {isOgCard ? null : <Nav />}
-        <main className={isOgCard ? "" : "mx-4 max-w-5xl border-x border-border lg:mx-auto"}>
+        <main
+          id="content"
+          className={isOgCard ? "" : "mx-4 max-w-5xl border-x border-border lg:mx-auto"}
+        >
           <Outlet />
         </main>
         {isOgCard ? null : <Footer />}


### PR DESCRIPTION
## What

Adds a skip-to-content link as the first focusable child of `<body>` in `__root.tsx`, and an `id="content"` target on `<main>`. The link is visually hidden by default (`sr-only`) and becomes visible only on keyboard focus (`focus:not-sr-only`), positioned at the top-left. It is gated on `!isOgCard` so it is excluded from OG card rendering, matching the existing treatment of `Nav`/`Footer`.

## Why

Audit finding: keyboard and screen-reader users had no way to bypass the persistent navigation and jump straight to main content. A skip link is a standard WCAG 2.4.1 (Bypass Blocks) accommodation. Focus styling reuses the app's existing convention (`focus-visible:ring-2 focus-visible:ring-accent`, as used in `nav.tsx` and `input.tsx`).

## Files touched

- `apps/www/src/routes/__root.tsx`

## Notes

- Build-validated (`bun run typecheck` + `bun run build` both pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: `apps/www/src/routes/__root.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add skip-to-content link for keyboard navigation in `RootDocument`
> Adds a 'Skip to content' anchor before the `Nav` component in [__root.tsx](https://github.com/851-labs/tokenmaxxing/pull/16/files#diff-9eb17af4bb2e99d1f20a633c7cb0b17bd843f182cc062813ee0ba6318b2a3c92) that is visually hidden until focused. The link targets `#content`, which is added as an `id` on the `<main>` element. The link is suppressed on OG card pages (paths under `/og-card/`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdcb55b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->