### PR TITLE
feat: JSON-LD structured data (Org, WebSite, SoftwareApp, FAQ, Profile, Breadcrumb)

### DIFF
--- a/apps/www/src/lib/jsonld.ts
+++ b/apps/www/src/lib/jsonld.ts
@@ -1,0 +1,164 @@
+import type { ProfileResponse } from "@tokenmaxxing/api-contract";
+
+import { profileOgDescription, profileOgTitle, SITE_ORIGIN } from "./og";
+
+type Profile = typeof ProfileResponse.Type;
+
+const ORGANIZATION_NAME = "851 Labs";
+const ORGANIZATION_ID = `${SITE_ORIGIN}/#organization`;
+const WEBSITE_ID = `${SITE_ORIGIN}/#website`;
+const SITE_NAME = "tokenmaxxing.sh";
+
+const ORGANIZATION_SAME_AS = [
+  "https://github.com/851-labs",
+  "https://x.com/851labs",
+  "https://discord.gg/851labs",
+];
+
+function organizationSchema(): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": ORGANIZATION_ID,
+    name: ORGANIZATION_NAME,
+    url: SITE_ORIGIN,
+    sameAs: ORGANIZATION_SAME_AS,
+  };
+}
+
+function webSiteSchema(): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": WEBSITE_ID,
+    name: SITE_NAME,
+    url: SITE_ORIGIN,
+    description: "The social leaderboard for LLM token usage. Sync your agents, climb the ranks.",
+    publisher: { "@id": ORGANIZATION_ID },
+  };
+}
+
+function softwareApplicationSchema(): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: "tokenmaxxing",
+    description:
+      "CLI that syncs local LLM agent usage and publishes it to the tokenmaxxing.sh leaderboard.",
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "macOS, Linux, Windows",
+    url: SITE_ORIGIN,
+    downloadUrl: "https://www.npmjs.com/package/@851-labs/tokenmaxxing",
+    installUrl: "https://www.npmjs.com/package/@851-labs/tokenmaxxing",
+    softwareHelp: { "@type": "CreativeWork", text: "npm install -g @851-labs/tokenmaxxing" },
+    publisher: { "@id": ORGANIZATION_ID },
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+  };
+}
+
+interface FaqItem {
+  answerText: string;
+  question: string;
+}
+
+function faqPageSchema(items: readonly FaqItem[]): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answerText,
+      },
+    })),
+  };
+}
+
+function profilePageSchema(profile: Profile): Record<string, unknown> {
+  const { stats, user } = profile;
+  const url = new URL(`/${encodeURIComponent(user.login)}`, SITE_ORIGIN).toString();
+
+  const person: Record<string, unknown> = {
+    "@type": "Person",
+    name: user.login,
+    identifier: user.login,
+    url,
+    sameAs: [`https://github.com/${user.login}`],
+  };
+
+  if (user.avatarUrl !== null) {
+    person.image = user.avatarUrl;
+  }
+
+  const schema: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    name: profileOgTitle(profile),
+    description: profileOgDescription(profile),
+    url,
+    mainEntity: person,
+  };
+
+  if (stats.activeDays > 0) {
+    const variableMeasured: Record<string, unknown>[] = [
+      { "@type": "PropertyValue", name: "totalSpendUsd", value: stats.totalSpendUsd },
+      { "@type": "PropertyValue", name: "totalTokens", value: stats.totalTokens },
+      { "@type": "PropertyValue", name: "activeDays", value: stats.activeDays },
+      { "@type": "PropertyValue", name: "sessionCount", value: stats.sessionCount },
+    ];
+
+    const dataset: Record<string, unknown> = {
+      "@type": "Dataset",
+      name: `${user.login} token usage`,
+      description: profileOgDescription(profile),
+      url,
+      variableMeasured,
+    };
+
+    if (stats.firstDate !== null && stats.lastDate !== null) {
+      dataset.temporalCoverage = `${stats.firstDate}/${stats.lastDate}`;
+    }
+
+    schema.about = dataset;
+  }
+
+  return schema;
+}
+
+function breadcrumbSchema(login: string, url: string): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: SITE_ORIGIN,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: login,
+        item: url,
+      },
+    ],
+  };
+}
+
+export {
+  breadcrumbSchema,
+  faqPageSchema,
+  organizationSchema,
+  profilePageSchema,
+  softwareApplicationSchema,
+  webSiteSchema,
+};
+
+export type { FaqItem };

--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -23,6 +23,7 @@ import { Avatar } from "../components/ui/avatar";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { Code } from "../components/ui/code";
+import { breadcrumbSchema, profilePageSchema } from "../lib/jsonld";
 import {
   OG_IMAGE_HEIGHT,
   OG_IMAGE_WIDTH,
@@ -66,6 +67,16 @@ const Route = createFileRoute("/$user")({
         { property: "og:image:height", content: String(OG_IMAGE_HEIGHT) },
         { name: "twitter:card", content: "summary_large_image" },
         { name: "twitter:image", content: image },
+      ],
+      scripts: [
+        {
+          type: "application/ld+json",
+          children: JSON.stringify(profilePageSchema(profile)),
+        },
+        {
+          type: "application/ld+json",
+          children: JSON.stringify(breadcrumbSchema(profile.user.login, url)),
+        },
       ],
     };
   },

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -9,6 +9,7 @@ import type { QueryClient } from "@tanstack/react-query";
 
 import { Footer } from "../components/footer";
 import { Nav } from "../components/nav";
+import { organizationSchema, webSiteSchema } from "../lib/jsonld";
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH, SITE_ORIGIN } from "../lib/og";
 import styles from "../styles.css?url";
 
@@ -42,6 +43,16 @@ function rootHead() {
       { name: "twitter:image", content: DEFAULT_OG_IMAGE_URL },
     ],
     links: [{ rel: "stylesheet", href: styles }],
+    scripts: [
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(organizationSchema()),
+      },
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(webSiteSchema()),
+      },
+    ],
   };
 }
 

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -12,6 +12,7 @@ import { Avatar } from "../components/ui/avatar";
 import { Code } from "../components/ui/code";
 import { Tabs } from "../components/ui/tabs";
 import { cn } from "../lib/cn";
+import { faqPageSchema, softwareApplicationSchema } from "../lib/jsonld";
 import { leaderboardQueryOptions } from "../lib/queries";
 
 const LEADERBOARD_METRIC_VALUES = ["spend", "tokens"] as const;
@@ -38,6 +39,22 @@ const Route = createFileRoute("/")({
   loader: async ({ context, deps }) => {
     await context.queryClient.ensureQueryData(leaderboardQueryOptions(deps.metric, deps.window));
   },
+  head: () => ({
+    scripts: [
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(softwareApplicationSchema()),
+      },
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(
+          faqPageSchema(
+            FAQ_ITEMS.map((item) => ({ answerText: item.answerText, question: item.question })),
+          ),
+        ),
+      },
+    ],
+  }),
   component: LeaderboardPage,
 });
 
@@ -80,10 +97,12 @@ const SUPPORTED_AGENTS = [
   { icon: <GeminiIcon />, label: "Gemini CLI" },
 ] as const;
 
-const FAQ_ITEMS: { answer: ReactNode; question: string }[] = [
+const FAQ_ITEMS: { answer: ReactNode; answerText: string; question: string }[] = [
   {
     question: "What is tokenmaxxing?",
     answer:
+      "tokenmaxxing is a public leaderboard for LLM agent usage. It syncs your local usage from supported coding agents, turns it into daily token and spend totals, and lets you compare with other users.",
+    answerText:
       "tokenmaxxing is a public leaderboard for LLM agent usage. It syncs your local usage from supported coding agents, turns it into daily token and spend totals, and lets you compare with other users.",
   },
   {
@@ -102,6 +121,8 @@ const FAQ_ITEMS: { answer: ReactNode; question: string }[] = [
         </span>
       </>
     ),
+    answerText:
+      "Install the CLI, then run the bootstrap command. Run `npm install -g @851-labs/tokenmaxxing`, then `tokenmaxxing bootstrap`. Bootstrap signs you in, syncs your usage, and can set up automatic syncing.",
   },
   {
     question: "Which agents does it support?",
@@ -119,20 +140,28 @@ const FAQ_ITEMS: { answer: ReactNode; question: string }[] = [
         to parse local usage from Claude Code, Codex, OpenCode, Gemini CLI, and Copilot CLI.
       </>
     ),
+    answerText:
+      "tokenmaxxing uses ccusage to parse local usage from Claude Code, Codex, OpenCode, Gemini CLI, and Copilot CLI.",
   },
   {
     question: "What data gets uploaded?",
     answer:
+      "Only daily aggregates: date, model name, agent source, token counts, and API-equivalent cost. Prompts, file paths, project names, and session content are never uploaded.",
+    answerText:
       "Only daily aggregates: date, model name, agent source, token counts, and API-equivalent cost. Prompts, file paths, project names, and session content are never uploaded.",
   },
   {
     question: "Why is usage data missing?",
     answer:
       "tokenmaxxing only reads usage data that still exists on your local computer. Some agents clean up old local logs automatically; for example, Claude Code can retain logs for only 30 days by default. If older local data has already been deleted, tokenmaxxing cannot recover or upload it.",
+    answerText:
+      "tokenmaxxing only reads usage data that still exists on your local computer. Some agents clean up old local logs automatically; for example, Claude Code can retain logs for only 30 days by default. If older local data has already been deleted, tokenmaxxing cannot recover or upload it.",
   },
   {
     question: "Are profiles public?",
     answer:
+      "Yes. Profiles and leaderboard totals are public. Device hostnames are shown only to you in settings and in your own per-device breakdown.",
+    answerText:
       "Yes. Profiles and leaderboard totals are public. Device hostnames are shown only to you in settings and in your own per-device breakdown.",
   },
   {
@@ -143,6 +172,8 @@ const FAQ_ITEMS: { answer: ReactNode; question: string }[] = [
         across devices, and sync is idempotent, so you can run it as often as you want.
       </>
     ),
+    answerText:
+      "Yes. Run `tokenmaxxing bootstrap` on each machine. Your profile aggregates usage across devices, and sync is idempotent, so you can run it as often as you want.",
   },
   {
     question: "How can I sync usage automatically?",
@@ -154,6 +185,8 @@ const FAQ_ITEMS: { answer: ReactNode; question: string }[] = [
         auto-update settings, and recent logs.
       </>
     ),
+    answerText:
+      "Run `tokenmaxxing service install` to install an optional background service that syncs every 5 minutes. Use `tokenmaxxing service status` to check the last run and `tokenmaxxing service doctor` to inspect scheduler files, auth, locks, auto-update settings, and recent logs.",
   },
   {
     question: "Can I delete or revoke access?",
@@ -164,10 +197,14 @@ const FAQ_ITEMS: { answer: ReactNode; question: string }[] = [
         settings page.
       </>
     ),
+    answerText:
+      "Yes. CLI tokens do not expire automatically, but you can revoke them with `tokenmaxxing logout` or from settings. You can also remove device data from your settings page.",
   },
   {
     question: "How is spend calculated?",
     answer:
+      "Spend is an API-equivalent estimate from the parsed usage data. It is meant for leaderboard comparison and usage tracking, not billing reconciliation.",
+    answerText:
       "Spend is an API-equivalent estimate from the parsed usage data. It is meant for leaderboard comparison and usage tracking, not billing reconciliation.",
   },
   {
@@ -179,6 +216,8 @@ const FAQ_ITEMS: { answer: ReactNode; question: string }[] = [
         <Code>--sources claude,codex</Code>.
       </>
     ),
+    answerText:
+      "Yes. Run `tokenmaxxing sync --dry-run` to see what would be pushed. You can also limit the range with `--since YYYY-MM-DD` or choose sources with flags like `--sources claude,codex`.",
   },
 ];
 


### PR DESCRIPTION
## What

Adds schema.org JSON-LD structured data across the site to make pages eligible for richer search results and to give crawlers/LLMs machine-readable context.

A new `apps/www/src/lib/jsonld.ts` exposes plain-object builders, injected via each route's `head().scripts` as `application/ld+json`:

- `__root.tsx` — `Organization` (851 Labs, sameAs github/x/discord) + `WebSite` on every page. SearchAction is intentionally omitted (no on-site search).
- `index.tsx` — `SoftwareApplication` (the `tokenmaxxing` CLI: DeveloperApplication, macOS/Linux/Windows, free Offer, npm install) + `FAQPage`.
- `$user.tsx` (loaderData branch) — `ProfilePage` wrapping a `Person` (sameAs `https://github.com/<login>`) plus a `Dataset` with `variableMeasured` PropertyValues (totalSpendUsd, totalTokens, activeDays, sessionCount) and `temporalCoverage` from firstDate/lastDate. The Dataset is omitted when `stats.activeDays === 0`. A `BreadcrumbList` (Home > {login}) is also injected.

## Why

Audit finding: the site shipped no structured data, leaving rich-result and entity signals on the table for search and AI crawlers.

## Notes

- The FAQ answers in `index.tsx` are mixed string/JSX. Rather than stringify a ReactNode, each `FAQ_ITEMS` entry gains a parallel `answerText: string`, and the FAQPage schema is built from that.
- Build-validated (typecheck + build pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: `apps/www/src/routes/__root.tsx`, `apps/www/src/routes/index.tsx`, `apps/www/src/routes/$user.tsx`.

## Files touched

- `apps/www/src/lib/jsonld.ts` (new)
- `apps/www/src/routes/__root.tsx`
- `apps/www/src/routes/index.tsx`
- `apps/www/src/routes/$user.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add JSON-LD structured data for Organization, WebSite, SoftwareApplication, FAQ, ProfilePage, and BreadcrumbList
> - Adds a [jsonld.ts](https://github.com/851-labs/tokenmaxxing/pull/17/files#diff-c0de020d962d304b1705c3bd5c079d24f0646788a621ab27730495f5a3eba735) utility module with schema generators for six Schema.org types: `organizationSchema`, `webSiteSchema`, `softwareApplicationSchema`, `faqPageSchema`, `profilePageSchema`, and `breadcrumbSchema`.
> - Injects Organization and WebSite schemas into the root document head via [__root.tsx](https://github.com/851-labs/tokenmaxxing/pull/17/files#diff-9eb17af4bb2e99d1f20a633c7cb0b17bd843f182cc062813ee0ba6318b2a3c92).
> - Injects SoftwareApplication and FAQPage schemas into the index page head via [index.tsx](https://github.com/851-labs/tokenmaxxing/pull/17/files#diff-007e41581e10251556a76461c0a6abe7114813e0499b9573e6c9f07c762e1cce); FAQ items now carry a plain-text `answerText` field alongside their React `answer` node.
> - Injects ProfilePage and BreadcrumbList schemas into the user profile page head via [$user.tsx](https://github.com/851-labs/tokenmaxxing/pull/17/files#diff-b144edf0ecacfa322bf976b90adabd811b06a96b18a9e2474520c75881814e20); the ProfilePage schema conditionally includes a Dataset with activity stats when `activeDays > 0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 632479f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->