### PR TITLE
perf: eager-load above-the-fold profile avatar

### DIFF
--- a/apps/www/src/components/ui/avatar.tsx
+++ b/apps/www/src/components/ui/avatar.tsx
@@ -11,10 +11,12 @@ interface AvatarProps {
   alt?: string;
   /** Edge length in pixels. */
   size?: AvatarSize;
+  /** Eager-load the image (use for above-the-fold avatars). */
+  priority?: boolean;
 }
 
 /** A square avatar image with a muted fallback when `src` is null. */
-function Avatar({ src, alt = "", size = 28 }: AvatarProps) {
+function Avatar({ src, alt = "", size = 28, priority = false }: AvatarProps) {
   const pixels = typeof size === "number" ? size : AVATAR_SIZES[size];
   const style = { width: pixels, height: pixels };
 
@@ -27,7 +29,8 @@ function Avatar({ src, alt = "", size = 28 }: AvatarProps) {
       alt={alt}
       className="shrink-0 select-none"
       draggable={false}
-      loading="lazy"
+      fetchPriority={priority ? "high" : undefined}
+      loading={priority ? "eager" : "lazy"}
       src={src}
       style={style}
     />

--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -89,7 +89,7 @@ function ProfilePage() {
     <>
       <header className="flex items-center justify-between gap-4 px-4 py-8">
         <div className="flex min-w-0 items-center gap-4">
-          <Avatar size={56} src={owner.avatarUrl} />
+          <Avatar priority size={56} src={owner.avatarUrl} />
           <h1 className="min-w-0 truncate text-2xl font-semibold tracking-tight">{owner.login}</h1>
         </div>
         <ProfileShareButton url={profileUrl(profile)} />


### PR DESCRIPTION
## What

Adds an optional \`priority\` prop to the \`Avatar\` component. When set, it renders the image with \`loading="eager"\` and \`fetchPriority="high"\` (default behavior remains \`loading="lazy"\`). The profile header avatar (size 56) in \`\$user.tsx\` now passes \`priority\`.

## Why

Per the SEO/perf audit: the profile header avatar is the above-the-fold hero image but was lazy-loaded, deferring its fetch and hurting LCP. Eager-loading it with high fetch priority lets the browser request it immediately.

## Files touched

- \`apps/www/src/components/ui/avatar.tsx\`
- \`apps/www/src/routes/\$user.tsx\`

Build-validated, not runtime-tested.

May conflict with other SEO PRs touching these files: \`apps/www/src/components/ui/avatar.tsx\`, \`apps/www/src/routes/\$user.tsx\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Eager-load above-the-fold profile avatar with high fetch priority
> Adds a `priority` prop to the `Avatar` component in [avatar.tsx](https://github.com/851-labs/tokenmaxxing/pull/18/files#diff-dd298d16b704afe124ae7fe072f767496c0466c55e00539e682aa73eac89c0a4) that switches `loading` to `"eager"` and sets `fetchPriority="high"` on the underlying `<img>`. The profile header in [\$user.tsx](https://github.com/851-labs/tokenmaxxing/pull/18/files#diff-b144edf0ecacfa322bf976b90adabd811b06a96b18a9e2474520c75881814e20) passes `priority` to ensure the avatar is fetched immediately on page load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfebe89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->