### PR TITLE
perf: load only latin subset of Geist Mono

### DIFF
--- a/apps/www/src/styles.css
+++ b/apps/www/src/styles.css
@@ -2,7 +2,7 @@
 @import "@fontsource/geist-sans/500.css";
 @import "@fontsource/geist-sans/600.css";
 @import "@fontsource/geist-sans/700.css";
-@import "@fontsource/geist-mono";
+@import "@fontsource/geist-mono/latin-400.css";
 @import "tailwindcss";
 
 :root {


### PR DESCRIPTION
## What

Replace the default `@import "@fontsource/geist-mono";` in `apps/www/src/styles.css` with the latin-only subset import `@import "@fontsource/geist-mono/latin-400.css";`. Geist Sans imports are left unchanged.

## Why

The audit flagged that the bare `@fontsource/geist-mono` import resolves to the package's `index.css`, which emits `@font-face` rules (and ships woff/woff2 files) for every subset: cyrillic, cyrillic-ext, vietnamese, latin-ext, symbols, and latin. The app only renders Latin text in mono (Code/Badge/Footer/leaderboard cells) and only at weight 400, so the non-Latin subsets are dead weight. Importing `latin-400.css` keeps mono rendering identical while dropping the unused font assets from the build (verified: `dist/client/assets` now contains only `geist-mono-latin-400-normal`).

## Files touched

- `apps/www/src/styles.css`

## Notes

- Build-validated (`typecheck` + `build` both pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: `apps/www/src/styles.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load only the latin-400 subset of Geist Mono font
> Changes the import in [styles.css](https://github.com/851-labs/tokenmaxxing/pull/19/files#diff-fa69c1e195d84eb2d17f456113b2a91908ea227fa10c369aa5403d7ed030547c) from the full `@fontsource/geist-mono` package to `@fontsource/geist-mono/latin-400.css`, reducing the font payload to only the latin subset at weight 400.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42f88a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->