### PR TITLE
perf: preload critical Geist woff2

### DIFF
--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { Footer } from "../components/footer";
 import { Nav } from "../components/nav";
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH, SITE_ORIGIN } from "../lib/og";
+import geistSans400 from "@fontsource/geist-sans/files/geist-sans-latin-400-normal.woff2?url";
 import styles from "../styles.css?url";
 
 interface RouterContext {
@@ -41,7 +42,16 @@ function rootHead() {
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:image", content: DEFAULT_OG_IMAGE_URL },
     ],
-    links: [{ rel: "stylesheet", href: styles }],
+    links: [
+      {
+        rel: "preload",
+        as: "font",
+        type: "font/woff2",
+        href: geistSans400,
+        crossOrigin: "anonymous" as const,
+      },
+      { rel: "stylesheet", href: styles },
+    ],
   };
 }
 


### PR DESCRIPTION
## What

Preload the above-the-fold **Geist Sans latin 400 normal** woff2 in the root document head. The font is imported with `?url` in `__root.tsx` so Vite emits a content-hashed asset path, and added to `rootHead().links` as `{ rel: "preload", as: "font", type: "font/woff2", href, crossOrigin: "anonymous" }`. Existing `@fontsource` `@import`s in `styles.css` are unchanged (font-display: swap remains the default).

## Why

Per the SEO/performance audit: the primary body font was only discovered after the browser parsed the stylesheet, delaying first paint of text and causing avoidable font-swap latency. Preloading the critical woff2 lets the browser fetch it in parallel with the CSS, improving FCP/CLS for first-time visitors.

Verified the emitted asset (`geist-sans-latin-400-normal-*.woff2`) resolves to a hashed path referenced in the server bundle, so the preload URL is valid in the build output.

## Files touched

- `apps/www/src/routes/__root.tsx`

## Notes

- Build-validated (typecheck + build pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: `apps/www/src/routes/__root.tsx`, `apps/www/src/styles.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preload Geist Sans 400 woff2 font in root head configuration
> Adds a `<link rel="preload">` entry for the Geist Sans latin-400 woff2 font in [__root.tsx](https://github.com/851-labs/tokenmaxxing/pull/20/files#diff-9eb17af4bb2e99d1f20a633c7cb0b17bd843f182cc062813ee0ba6318b2a3c92) before the existing stylesheet link. This reduces render-blocking by hinting the browser to fetch the font earlier.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d812fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->