### PR TITLE
feat: edge cache headers for HTML & immutable assets

### DIFF
--- a/apps/www/public/_headers
+++ b/apps/www/public/_headers
@@ -1,0 +1,2 @@
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/apps/www/src/lib/cache-headers.ts
+++ b/apps/www/src/lib/cache-headers.ts
@@ -1,0 +1,51 @@
+import { createIsomorphicFn } from "@tanstack/react-start";
+
+/**
+ * Edge caching for public, non-personalized HTML. The Nav SSRs authenticated
+ * UI whenever a session cookie rides along, so any request carrying the
+ * session cookie MUST NOT be edge-cached — otherwise one user's authed HTML
+ * could be served to anonymous visitors (or vice versa).
+ *
+ * `headers()` route options run during SSR on the server but receive no
+ * request object, so we read the inbound cookie the same way `lib/api.ts`
+ * does: via `getRequestHeader` behind `createIsomorphicFn` (a no-op on the
+ * client). When a session cookie is present we fall back to `private,
+ * no-store` and add `Vary: Cookie`.
+ */
+
+const SESSION_COOKIE = "tmx_session";
+
+const PRIVATE_CACHE_HEADERS: Record<string, string> = {
+  "Cache-Control": "private, no-store",
+  Vary: "Cookie",
+};
+
+const sessionCookiePresent = createIsomorphicFn()
+  .client(() => false)
+  .server(async () => {
+    const { getRequestHeader } = await import("@tanstack/react-start/server");
+    const cookie = getRequestHeader("cookie");
+    if (cookie === undefined) {
+      return false;
+    }
+
+    // Match the cookie name at a boundary so e.g. `tmx_session_other` cannot
+    // false-positive, and a present-but-empty value (cleared on sign-out) does
+    // not count as a session.
+    const match = new RegExp(`(?:^|;\\s*)${SESSION_COOKIE}=([^;]*)`).exec(cookie);
+    return match !== null && match[1] !== "";
+  });
+
+/**
+ * Resolve cache headers for a public HTML route: shared edge caching for
+ * anonymous requests, `private, no-store` for any request with a session.
+ */
+async function publicHtmlCacheHeaders(publicCacheControl: string): Promise<Record<string, string>> {
+  if (await sessionCookiePresent()) {
+    return PRIVATE_CACHE_HEADERS;
+  }
+
+  return { "Cache-Control": publicCacheControl };
+}
+
+export { PRIVATE_CACHE_HEADERS, publicHtmlCacheHeaders, SESSION_COOKIE };

--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -23,6 +23,7 @@ import { Avatar } from "../components/ui/avatar";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { Code } from "../components/ui/code";
+import { publicHtmlCacheHeaders } from "../lib/cache-headers";
 import {
   OG_IMAGE_HEIGHT,
   OG_IMAGE_WIDTH,
@@ -42,6 +43,8 @@ const Route = createFileRoute("/$user")({
 
     return { daily, profile };
   },
+  headers: () =>
+    publicHtmlCacheHeaders("public, max-age=0, s-maxage=120, stale-while-revalidate=300"),
   head: ({ loaderData }) => {
     if (loaderData === undefined) {
       return {};

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -11,6 +11,7 @@ import { formatTokens, formatUsd } from "../components/charts/scale";
 import { Avatar } from "../components/ui/avatar";
 import { Code } from "../components/ui/code";
 import { Tabs } from "../components/ui/tabs";
+import { publicHtmlCacheHeaders } from "../lib/cache-headers";
 import { cn } from "../lib/cn";
 import { leaderboardQueryOptions } from "../lib/queries";
 
@@ -38,6 +39,8 @@ const Route = createFileRoute("/")({
   loader: async ({ context, deps }) => {
     await context.queryClient.ensureQueryData(leaderboardQueryOptions(deps.metric, deps.window));
   },
+  headers: () =>
+    publicHtmlCacheHeaders("public, max-age=0, s-maxage=60, stale-while-revalidate=300"),
   component: LeaderboardPage,
 });
 


### PR DESCRIPTION
## What & why

The SEO/perf audit found that the public leaderboard (`/`) and profile (`/$user`) HTML responses had no edge-cache headers, so every request hit the origin worker (and re-ran the loaders / API calls) even though the content is identical for all anonymous visitors. Fingerprinted assets under `/assets/*` were also not marked immutable.

This PR adds:

- **HTML edge caching** via TanStack Start route `headers()`:
  - `/` → `public, max-age=0, s-maxage=60, stale-while-revalidate=300`
  - `/$user` → `public, max-age=0, s-maxage=120, stale-while-revalidate=300`
- **Immutable asset caching** via `apps/www/public/_headers`:
  - `/assets/*` → `public, max-age=31536000, immutable`

### Auth-leak safety (critical)

`Nav` SSRs authenticated UI whenever the `tmx_session` cookie is present, so personalized HTML must never be edge-cached. The route `headers()` context in this router version (`@tanstack/router-core` 1.171) does **not** include the request, so the cookie is read on the server via `getRequestHeader("cookie")` behind `createIsomorphicFn` — the same proven pattern as `lib/api.ts` (no-op on the client). The new `lib/cache-headers.ts` helper returns `Cache-Control: private, no-store` + `Vary: Cookie` for any request carrying a non-empty `tmx_session` cookie, and the public `s-maxage` only for anonymous requests. A present-but-empty cookie (cleared on sign-out) is treated as anonymous.

## Files touched

- `apps/www/src/lib/cache-headers.ts` (new) — cookie-gated cache-header helper
- `apps/www/src/routes/index.tsx` — `headers()` on `/`
- `apps/www/src/routes/$user.tsx` — `headers()` on `/$user`
- `apps/www/public/_headers` (new) — immutable `/assets/*` caching

## Notes

- Build-validated (`typecheck` + `build` both pass), not runtime-tested.
- May conflict with other SEO PRs touching these files: `routes/index.tsx`, `routes/$user.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add edge cache headers for HTML routes and immutable static assets
> - Adds a [`_headers`](https://github.com/851-labs/tokenmaxxing/pull/21/files#diff-e7da1ca1213b33cc692b74d3d9f8802fb3bf3751dee2dc8752cc862567f89820) file that sets `Cache-Control: public, max-age=31536000, immutable` for all `/assets/*` responses.
> - Introduces [`cache-headers.ts`](https://github.com/851-labs/tokenmaxxing/pull/21/files#diff-ee7ac952f9f36f1fb13a531435d37e0c3cedf40c72c0b1c8ced10218edabe7f2) with a `publicHtmlCacheHeaders` helper that returns `private, no-store` + `Vary: Cookie` when a `tmx_session` cookie is present, or a caller-supplied public directive otherwise.
> - Applies this helper to the `/` route (`s-maxage=60`) and `/$user` route (`s-maxage=120`), both with `stale-while-revalidate=300` for anonymous requests.
> - Behavioral Change: authenticated users (those with a `tmx_session` cookie) will now receive `private, no-store` headers instead of no explicit cache directive on these routes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8dc349.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->