### PR TITLE
feat: always redirect HTTP to HTTPS (zone setting)

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -1,4 +1,5 @@
 import { localState, Stack } from "alchemy";
+import { adopt } from "alchemy/AdoptPolicy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
@@ -42,11 +43,47 @@ const stack = Stack(
       },
     });
 
+    // Force HTTPS on the apex zone. Cloudflare exposes this as the
+    // `always_use_https` zone setting, but the installed alchemy version has no
+    // `ZoneSetting` resource — the supported way to express it is a dynamic
+    // redirect rule in the `http_request_dynamic_redirect` phase that rewrites
+    // every non-TLS request to its `https://` equivalent with a 301.
+    //
+    // The zone already exists in Cloudflare (created out-of-band), so adopt it
+    // rather than provisioning a new one. Zones default to retain-on-removal.
+    const zone = yield* Cloudflare.Zone("tokenmaxxing-sh", {
+      name: "tokenmaxxing.sh",
+    }).pipe(adopt(true));
+
+    const httpsRedirect = yield* Cloudflare.Ruleset("always-use-https", {
+      zone,
+      phase: "http_request_dynamic_redirect",
+      description: "Always redirect HTTP to HTTPS",
+      rules: [
+        {
+          description: "Redirect all HTTP requests to HTTPS",
+          expression: "not ssl",
+          action: "redirect",
+          actionParameters: {
+            fromValue: {
+              targetUrl: {
+                expression: 'concat("https://", http.host, http.request.uri.path)',
+              },
+              preserveQueryString: true,
+              statusCode: "301",
+            },
+          },
+        },
+      ],
+    });
+
     return {
       api,
       bucket,
       db,
       www,
+      zone,
+      httpsRedirect,
     };
   }),
 );


### PR DESCRIPTION
## What

Adds infrastructure to force HTTPS on the `tokenmaxxing.sh` zone. Every plaintext HTTP request is now 301-redirected to its `https://` equivalent (preserving path and query string) — i.e. the Cloudflare `always_use_https` behavior.

## Why

Audit finding: the site was reachable over plain HTTP with no enforced upgrade to HTTPS. Forcing HTTPS protects users, avoids duplicate http/https URLs in search indexes, and is a baseline SEO/security expectation.

## How

The installed alchemy version (`2.0.0-beta.52`) ships **no** `Cloudflare.ZoneSetting` resource, so the literal `always_use_https` zone setting cannot be set directly. The supported equivalent is a dynamic redirect rule:

- Adopt the existing `tokenmaxxing.sh` `Cloudflare.Zone` (zones default to retain-on-removal; `adopt(true)` takes over the out-of-band zone).
- Add a `Cloudflare.Ruleset` in the `http_request_dynamic_redirect` phase with a single `redirect` rule:
  - expression `not ssl`
  - target `concat("https://", http.host, http.request.uri.path)`, `preserveQueryString: true`, `statusCode: "301"`.

The rule shape (`actionParameters.fromValue.targetUrl.expression`) was verified against the installed `@distilled.cloud/cloudflare` ruleset types.

### Uncertainty / verify before merge

- This adopts the existing zone via `adopt(true)`. If the zone is *not* already present in Cloudflare under this account, planning will fail — confirm the zone exists before deploying.
- The `Cloudflare.Ruleset` owns the entire `http_request_dynamic_redirect` phase entrypoint; any redirect rules managed elsewhere in that phase would be overwritten. Confirm no other redirect rules live in that phase.
- Build-validated, not runtime-tested.

## Files touched

- `alchemy.run.ts`

May conflict with other SEO PRs touching these files: `alchemy.run.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add HTTP to HTTPS 301 redirect ruleset for tokenmaxxing.sh zone
> - Adopts the existing Cloudflare zone `tokenmaxxing.sh` in [alchemy.run.ts](https://github.com/851-labs/tokenmaxxing/pull/22/files#diff-b3d72a565086024fa77fad98aa8727945a55990b8b2b0605296d35b1d94febbc) using `adopt(true)`.
> - Provisions a `http_request_dynamic_redirect` ruleset that matches all non-SSL requests and issues a 301 redirect to the equivalent `https://` URL, preserving host, path, and query string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95243b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->