### PR TITLE
perf: trim unused fields from profile daily payload

### DIFF
--- a/apps/api/src/profiles/d1.ts
+++ b/apps/api/src/profiles/d1.ts
@@ -148,11 +148,8 @@ const makeD1ProfilesRepository = Effect.fn("makeD1ProfilesRepository")(function*
         const rows = yield* database.use((db) => {
           const base = db
             .select({
-              cacheCreationTokens: sql<number>`sum(${usageDays.cacheCreationTokens})`,
-              cacheReadTokens: sql<number>`sum(${usageDays.cacheReadTokens})`,
               costUsd: sql<number>`sum(${usageDays.costUsd})`,
               date: usageDays.date,
-              inputTokens: sql<number>`sum(${usageDays.inputTokens})`,
               key: sql<string>`${key}`.as("group_key"),
               outputTokens: sql<number>`sum(${usageDays.outputTokens})`,
               totalTokens: sql<number>`sum(${usageDays.totalTokens})`,

--- a/packages/api-contract/src/schemas.test.ts
+++ b/packages/api-contract/src/schemas.test.ts
@@ -120,11 +120,8 @@ describe("profile daily responses", () => {
       Schema.decodeUnknownPromise(ProfileDailyResponse)({
         days: [
           {
-            cacheCreationTokens: 0,
-            cacheReadTokens: 0,
             costUsd: 12.34,
             date: "2026-06-19",
-            inputTokens: 100,
             key: "claude-opus-4",
             outputTokens: 200,
             totalTokens: 300,
@@ -138,11 +135,8 @@ describe("profile daily responses", () => {
     ).resolves.toEqual({
       days: [
         {
-          cacheCreationTokens: 0,
-          cacheReadTokens: 0,
           costUsd: 12.34,
           date: "2026-06-19",
-          inputTokens: 100,
           key: "claude-opus-4",
           outputTokens: 200,
           totalTokens: 300,

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -314,13 +314,14 @@ const ProfileDailyGroupBy = Schema.Literals(["model", "source", "device"]);
 
 type ProfileDailyGroupBy = typeof ProfileDailyGroupBy.Type;
 
-/** One row per (date, key); `key` is the model/source/device the row groups by. */
+/**
+ * One row per (date, key); `key` is the model/source/device the row groups by.
+ * Only the fields the profile charts read are carried on the wire — input/cache
+ * token breakdowns are intentionally omitted to keep the profile payload small.
+ */
 const ProfileDailyRow = Schema.Struct({
-  cacheCreationTokens: Schema.Number,
-  cacheReadTokens: Schema.Number,
   costUsd: Schema.Number,
   date: Schema.String,
-  inputTokens: Schema.Number,
   key: Schema.String,
   outputTokens: Schema.Number,
   totalTokens: Schema.Number,


### PR DESCRIPTION
## What

Shrinks the ~629KB profile HTML payload by removing three per-row fields the profile UI never reads from the profile daily endpoint:

- `inputTokens`
- `cacheReadTokens`
- `cacheCreationTokens`

`deriveCharts` in `apps/www/src/routes/$user.tsx` only consumes `date` / `key` / `costUsd` / `totalTokens` / `outputTokens`. The three dropped fields were serialized on every daily row for no consumer.

## Why

Audit finding: the profile page ships a large inlined SSR payload; per-row token breakdowns were dead weight on the wire (and in the SSR HTML hydration data).

### Consumer investigation (confirmed safe)

The only consumers of `ProfileDailyRow` are:
- `packages/api-contract/src/api.ts` — `daily` endpoint `success` schema
- `apps/api/src/profiles/service.ts` / `apps/api/src/profiles/d1.ts` — the producer
- `apps/www/src/routes/$user.tsx` — the consumer (uses 5 of the 8 fields)

The `inputTokens` / `cacheReadTokens` / `cacheCreationTokens` matches in `apps/cli` and `apps/api/src/usage` belong to the **separate** `UsageDayInput` ingestion schema (the CLI upload path), not `ProfileDailyRow`, and are untouched.

## Files touched

- `packages/api-contract/src/schemas.ts` — drop the three fields from `ProfileDailyRow`
- `packages/api-contract/src/schemas.test.ts` — update the daily-decode fixture
- `apps/api/src/profiles/d1.ts` — stop selecting/summing the three columns in the daily query

## Validation

- `packages/api-contract`: `tsc --noEmit` clean; schema tests pass (3/3, including the profile daily decode).
- `apps/www`: full `tsc --noEmit` clean (consumer unaffected).
- `apps/api`: could not typecheck in the worktree (no `drizzle-orm` installed — 85 identical baseline errors without this change); the edit is a type-compatible removal of three SQL select keys, narrowing the result type exactly to the trimmed `ProfileDailyRow`.

Build-validated, not runtime-tested.

May conflict with other SEO PRs touching these files: `apps/www/src/routes/$user.tsx`, `packages/api-contract`, `apps/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused token fields from `ProfileDailyRow` wire payload
> Drops `cacheCreationTokens`, `cacheReadTokens`, and `inputTokens` from the daily profile aggregation query in [d1.ts](https://github.com/851-labs/tokenmaxxing/pull/23/files#diff-1547ddf18549a7c513a59edfef5b84a343815e4962c1dbf18fbe73ae9bd07379) and from the `ProfileDailyRow` schema in [schemas.ts](https://github.com/851-labs/tokenmaxxing/pull/23/files#diff-670e6947879bb77c35790f560f22b2f77ce86d9adf874c6808cbc09841c6a38c). Only fields used by profile charts (`costUsd`, `date`, `key`, `outputTokens`, `totalTokens`) are now included. Behavioral Change: any consumer reading these three fields from `ProfileDailyRow` will no longer receive them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80d186e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->