### PR TITLE
fix(www): repair daily-row test fixtures broken by #23

### DIFF
--- a/apps/www/src/routes/-$user.test.ts
+++ b/apps/www/src/routes/-$user.test.ts
@@ -14,11 +14,8 @@ describe("deriveCharts", () => {
     };
     const rows: DailyRow[] = [
       {
-        cacheCreationTokens: 0,
-        cacheReadTokens: 0,
         costUsd: 12,
         date: "2026-06-19",
-        inputTokens: 100,
         key: "claude-opus-4",
         outputTokens: 200,
         totalTokens: 300,
@@ -115,11 +112,8 @@ function dailyRow({
   totalTokens: number;
 }): DailyRow {
   return {
-    cacheCreationTokens: 0,
-    cacheReadTokens: 0,
     costUsd,
     date: "2026-06-21",
-    inputTokens: 0,
     key,
     outputTokens: 0,
     totalTokens,

--- a/apps/www/src/routes/-og.test.ts
+++ b/apps/www/src/routes/-og.test.ts
@@ -221,11 +221,8 @@ function daily(): Daily {
   return {
     days: [
       {
-        cacheCreationTokens: 0,
-        cacheReadTokens: 0,
         costUsd: 12.34,
         date: "2026-06-21",
-        inputTokens: 100,
         key: "claude-opus",
         outputTokens: 200,
         totalTokens: 300,


### PR DESCRIPTION
#23 trimmed `inputTokens`/`cacheReadTokens`/`cacheCreationTokens` from `ProfileDailyRow`, but the www test fixtures (`-$user.test.ts`, `-og.test.ts`) still set those fields — so `bun run typecheck` was failing on main. (#23 validated against the unedited contract via the workspace symlink, so it missed this.) This removes the stale fields.

Verified: `typecheck` clean, `test` 25/25 pass, `build` OK. Production was unaffected (vite build doesn't typecheck or bundle tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken `dailyRow` and `daily` test fixtures by removing token fields added in #23
> Removes `cacheCreationTokens`, `cacheReadTokens`, and `inputTokens` from the `DailyRow` objects constructed in [apps/www/src/routes/-$user.test.ts](https://github.com/851-labs/tokenmaxxing/pull/24/files#diff-87045851cb4b3f625b1367f19994540d68daa8c915b28e02f1d56f12ba4cb1d8) and [-og.test.ts](https://github.com/851-labs/tokenmaxxing/pull/24/files#diff-7d050396d3bfef4a2a2c993fd90e814c96375dd835bd4274bb4188fa42c065b5). The `dailyRow` and `daily` test helpers now return objects with only `costUsd`, `date`, `key`, `outputTokens`, and `totalTokens`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 454965c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->