### PR TITLE
feat(cli): sync pi-agent usage via ccusage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tokenmaxxing
 
 The social leaderboard for LLM token usage. Sync your local agent usage
-(Claude Code, Codex, OpenCode, Gemini CLI, Copilot CLI), climb the board at
+(Claude Code, Codex, OpenCode, Gemini CLI, Copilot CLI, Pi), climb the board at
 [tokenmaxxing.sh](https://tokenmaxxing.sh).
 
 Built on [ccusage](https://github.com/ryoppippi/ccusage) for local usage

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -2,7 +2,7 @@
 
 CLI for [tokenmaxxing](https://tokenmaxxing.sh) — the social leaderboard
 for LLM token usage. Parses your local agent usage (Claude Code, Codex,
-OpenCode, Gemini CLI, Copilot CLI) via
+OpenCode, Gemini CLI, Copilot CLI, Pi) via
 [ccusage](https://github.com/ryoppippi/ccusage) and pushes daily aggregates
 to your public profile.
 

--- a/apps/cli/src/ccusage/sources.test.ts
+++ b/apps/cli/src/ccusage/sources.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SOURCE_NAMES, resolveSources } from "./sources";
+
+describe("resolveSources", () => {
+  it("accepts every default source", () => {
+    const { invalid, sources } = resolveSources(DEFAULT_SOURCE_NAMES);
+    expect(invalid).toEqual([]);
+    expect(sources.map((entry) => entry.source)).toEqual(DEFAULT_SOURCE_NAMES);
+  });
+
+  it("resolves the pi-agent source to the ccusage `pi` subcommand", () => {
+    const { invalid, sources } = resolveSources(["pi"]);
+    expect(invalid).toEqual([]);
+    expect(sources).toEqual([{ source: "pi", subcommand: "pi" }]);
+  });
+
+  it("rejects unknown sources", () => {
+    expect(resolveSources(["bogus"]).invalid).toEqual(["bogus"]);
+  });
+});

--- a/apps/cli/src/ccusage/sources.ts
+++ b/apps/cli/src/ccusage/sources.ts
@@ -18,6 +18,7 @@ const CCUSAGE_SOURCES: readonly CcusageSource[] = [
   { source: "opencode", subcommand: "opencode" },
   { source: "gemini", subcommand: "gemini" },
   { source: "copilot", subcommand: "copilot" },
+  { source: "pi", subcommand: "pi" },
 ];
 
 const DEFAULT_SOURCE_NAMES = CCUSAGE_SOURCES.map((entry) => entry.source);

--- a/apps/cli/src/commands/service.test.ts
+++ b/apps/cli/src/commands/service.test.ts
@@ -1335,12 +1335,22 @@ describe("service auto-update reports", () => {
 });
 
 describe("serviceScheduledSyncSince", () => {
-  it("uses the previous successful local date for scheduled syncs", () => {
+  it("uses the previous successful date for scheduled syncs", () => {
+    // Bucket key injected so the assertion is stable regardless of host timezone;
+    // runtime uses localDateKey (the default) to bucket in the device's local time.
+    const utcDateKey = (date: Date): string =>
+      [
+        date.getUTCFullYear(),
+        String(date.getUTCMonth() + 1).padStart(2, "0"),
+        String(date.getUTCDate()).padStart(2, "0"),
+      ].join("-");
+
     expect(
       serviceScheduledSyncSince(
         { lastSuccessAt: "2026-06-16T23:30:00.000Z", version: 1 },
         new Date("2026-06-17T00:05:00.000Z"),
         true,
+        utcDateKey,
       ),
     ).toBe("2026-06-16");
   });

--- a/apps/cli/src/commands/service.ts
+++ b/apps/cli/src/commands/service.ts
@@ -1948,6 +1948,8 @@ function serviceScheduledSyncSince(
   state: ServiceState,
   now: Date,
   scheduled: boolean,
+  /** Local-time bucket key by default; injectable for timezone-stable tests. */
+  toKey: (date: Date) => string = localDateKey,
 ): string | undefined {
   if (!scheduled) {
     return undefined;
@@ -1956,11 +1958,11 @@ function serviceScheduledSyncSince(
   if (state.lastSuccessAt !== undefined) {
     const lastSuccessAt = new Date(state.lastSuccessAt);
     if (!Number.isNaN(lastSuccessAt.getTime()) && lastSuccessAt.getTime() <= now.getTime()) {
-      return localDateKey(lastSuccessAt);
+      return toKey(lastSuccessAt);
     }
   }
 
-  const today = localDateKey(now);
+  const today = toKey(now);
   if (
     state.lastSuccessDate !== undefined &&
     isLocalDateKey(state.lastSuccessDate) &&
@@ -1969,7 +1971,7 @@ function serviceScheduledSyncSince(
     return state.lastSuccessDate;
   }
 
-  return previousLocalDateKey(now);
+  return previousDateKey(today);
 }
 
 function localDateKey(date: Date): string {
@@ -1980,8 +1982,15 @@ function localDateKey(date: Date): string {
   ].join("-");
 }
 
-function previousLocalDateKey(date: Date): string {
-  return localDateKey(new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1));
+/** Calendar day before a `YYYY-MM-DD` key. UTC normalization keeps it timezone-independent. */
+function previousDateKey(key: string): string {
+  const [year, month, day] = key.split("-").map(Number) as [number, number, number];
+  const previous = new Date(Date.UTC(year, month - 1, day - 1));
+  return [
+    previous.getUTCFullYear(),
+    String(previous.getUTCMonth() + 1).padStart(2, "0"),
+    String(previous.getUTCDate()).padStart(2, "0"),
+  ].join("-");
 }
 
 function isLocalDateKey(value: string): boolean {


### PR DESCRIPTION
## What

Register the `pi` ccusage subcommand as a sync source so Pi (https://pi.dev) usage rolls up under a `pi` source tag.

ccusage already ships `ccusage pi daily`; the CLI shells out to one `ccusage <subcommand> daily` run per source and tags rows with `source`. The aggregator/schema already handle ccusage's per-source dialects, and `source` is a free-form string server-side — so `sources.ts` is the single registration point:

```ts
{ source: "pi", subcommand: "pi" },
```

The `--sources` help text and unknown-source error auto-include `pi` via `DEFAULT_SOURCE_NAMES`.

## Changes

- `apps/cli/src/ccusage/sources.ts` — register the `pi` source
- `apps/cli/src/ccusage/sources.test.ts` — guard the registration + subcommand mapping + unknown-source rejection
- `README.md`, `apps/cli/README.md` — document Pi

## Prerequisite: timezone-stable test fix

A pre-existing test (`serviceScheduledSyncSince`) asserted a machine-local date string against UTC instants, so it only passed in UTC/US zones and blocked CI. Fixed as a separate commit: the bucket key is now injectable (default unchanged) and the test uses a UTC key. Happy to split into its own PR if you'd prefer this one stay focused on the source addition.
