### PR TITLE
fix: Windows ccusage launch for sync

### DIFF
--- a/apps/cli/src/ccusage/runner.test.ts
+++ b/apps/cli/src/ccusage/runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { dailyCcusageCommand, sessionCcusageCommand } from "./runner";
+import { ccusageCommandInvocations, dailyCcusageCommand, sessionCcusageCommand } from "./runner";
 
 const codex = { source: "codex", subcommand: "codex" };
 
@@ -22,6 +22,15 @@ describe("ccusage commands", () => {
       "--json",
       "--mode",
       "calculate",
+    ]);
+  });
+});
+
+describe("ccusageCommandInvocations", () => {
+  it("uses executable commands instead of shell aliases on Windows", () => {
+    expect(ccusageCommandInvocations(["codex", "daily"], "win32")).toEqual([
+      { args: ["x", "ccusage@^20.0.17", "codex", "daily"], command: "bun" },
+      { args: ["-y", "ccusage@^20.0.17", "codex", "daily"], command: "npx.cmd" },
     ]);
   });
 });

--- a/apps/cli/src/ccusage/runner.ts
+++ b/apps/cli/src/ccusage/runner.ts
@@ -7,8 +7,8 @@ import { decodeDailyReport, decodeSessionReport } from "./schema";
 import type { CcusageSource } from "./sources";
 
 /**
- * Shells out to `bunx ccusage@^20.0.17 <source> daily --json --breakdown` (npx
- * fallback only when bunx itself is missing). A source that fails, is not
+ * Shells out to `bun x ccusage@^20.0.17 <source> daily --json --breakdown` (npx
+ * fallback only when bun itself is missing). A source that fails, is not
  * installed, or has no local data resolves to none — one broken agent must
  * never abort the whole sync.
  */
@@ -24,6 +24,11 @@ class CcusageRunError extends Data.TaggedError("CcusageRunError")<{
 interface RunOptions {
   /** YYYY-MM-DD; forwarded to ccusage as compact YYYYMMDD. */
   since?: string | undefined;
+}
+
+interface CcusageCommandInvocation {
+  args: string[];
+  command: string;
 }
 
 function runCcusageDailyReport(
@@ -115,13 +120,23 @@ function execCcusage(args: string[], source: string): Effect.Effect<string, Ccus
       });
     });
 
-  return run("bunx", [CCUSAGE_SPEC, ...args]).pipe(
+  const [primary, fallback] = ccusageCommandInvocations(args);
+
+  return run(primary.command, primary.args).pipe(
     Effect.catch((error: CcusageRunError) =>
-      isMissingCommand(error.cause)
-        ? run("npx", ["-y", CCUSAGE_SPEC, ...args])
-        : Effect.fail(error),
+      isMissingCommand(error.cause) ? run(fallback.command, fallback.args) : Effect.fail(error),
     ),
   );
+}
+
+function ccusageCommandInvocations(
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): [CcusageCommandInvocation, CcusageCommandInvocation] {
+  return [
+    { args: ["x", CCUSAGE_SPEC, ...args], command: "bun" },
+    { args: ["-y", CCUSAGE_SPEC, ...args], command: platform === "win32" ? "npx.cmd" : "npx" },
+  ];
 }
 
 function isMissingCommand(cause: unknown): boolean {
@@ -129,6 +144,7 @@ function isMissingCommand(cause: unknown): boolean {
 }
 
 export {
+  ccusageCommandInvocations,
   dailyCcusageCommand,
   runCcusageDailyReport,
   runCcusageSessionReport,

--- a/apps/cli/src/commands/sync.test.ts
+++ b/apps/cli/src/commands/sync.test.ts
@@ -196,12 +196,32 @@ type TestUsageIngest = (
   request: TestUsageIngestRequest,
 ) => Effect.Effect<{ received: number; syncedAt: string; upserted: number }, unknown>;
 
-function makeUploadAuth(ingest: TestUsageIngest): SyncAuth {
+interface TestUsageSyncRequest {
+  payload: {
+    days: unknown[];
+    device: {
+      name: string;
+      platform: NodeJS.Platform;
+    };
+    sourceStats?: unknown[] | undefined;
+  };
+}
+
+type TestUsageSync = (
+  request: TestUsageSyncRequest,
+) => Effect.Effect<{ received: number; syncedAt: string; upserted: number }, unknown>;
+
+function makeUploadAuth(
+  ingest: TestUsageIngest,
+  sync: TestUsageSync = () =>
+    Effect.succeed({ received: 0, syncedAt: "2026-06-15T00:00:00.000Z", upserted: 0 }),
+): SyncAuth {
   return {
     authSource: "stored",
     client: {
       usage: {
         ingest,
+        sync,
       },
     } as unknown as TokenmaxxingApiClient,
     config: {
@@ -348,6 +368,59 @@ describe("uploadUsageReports", () => {
     expect(payloads).toEqual([{ device: { name: "Mac.local", platform: "darwin" }, reports: [] }]);
     expect(state.logs).toEqual(["Uploading usage", "Usage uploaded"]);
     expect(state.errors).toEqual([]);
+  });
+
+  it("bounds session uploads and restores the total session count", async () => {
+    const { layer } = makeConsoleLayer();
+    const ingestPayloads: TestUsageIngestRequest["payload"][] = [];
+    const syncPayloads: TestUsageSyncRequest["payload"][] = [];
+    const auth = makeUploadAuth(
+      (request) =>
+        Effect.sync(() => {
+          ingestPayloads.push(request.payload);
+          return {
+            received: request.payload.reports.length,
+            syncedAt: "2026-06-15T00:00:00.000Z",
+            upserted: 0,
+          };
+        }),
+      (request) =>
+        Effect.sync(() => {
+          syncPayloads.push(request.payload);
+          return { received: 0, syncedAt: "2026-06-15T00:00:01.000Z", upserted: 0 };
+        }),
+    );
+
+    await Effect.runPromise(
+      uploadUsageReports({
+        auth,
+        device: { name: "Windows.local", platform: "win32" },
+        options: { json: true },
+        rawReports: [
+          {
+            command: ["ccusage@^20.0.17", "codex", "session", "--json"],
+            payload: { sessions: Array.from({ length: 5_001 }, (_, id) => ({ id })) },
+            reportKind: "session",
+            source: "codex",
+          },
+        ],
+        sourceStats: [{ sessionCount: 5_001, source: "codex" }],
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(
+      ingestPayloads.map(
+        (payload) =>
+          (payload.reports[0] as { payload: { sessions: unknown[] } }).payload.sessions.length,
+      ),
+    ).toEqual([5_000, 1]);
+    expect(syncPayloads).toEqual([
+      {
+        days: [],
+        device: { name: "Windows.local", platform: "win32" },
+        sourceStats: [{ sessionCount: 5_001, source: "codex" }],
+      },
+    ]);
   });
 
   it("marks the upload row as failed when ingest fails", async () => {

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -176,6 +176,7 @@ interface UploadUsageReportsOptions {
   };
   options: Pick<SyncProgramOptions, "json" | "silent">;
   rawReports: RawUsageReportInput[];
+  sourceStats?: SourceUsageStatsInput[] | undefined;
   uploadPolicy?: UploadRetryPolicy | undefined;
 }
 
@@ -323,6 +324,7 @@ function syncProgram(options: SyncProgramOptions) {
       device,
       options,
       rawReports,
+      sourceStats: options.since === undefined ? sourceStatsForSync(sourceResults) : undefined,
       uploadPolicy: options.uploadPolicy,
     });
     upserted = response.upserted;
@@ -344,11 +346,12 @@ function uploadUsageReports({
   device,
   options,
   rawReports,
+  sourceStats,
   uploadPolicy,
 }: UploadUsageReportsOptions) {
   return Effect.gen(function* () {
     const spinner = yield* humanSpinner("Uploading usage", options);
-    const upload = uploadUsageReportsOnce({ auth, device, rawReports }, uploadPolicy);
+    const upload = uploadUsageReportsOnce({ auth, device, rawReports, sourceStats }, uploadPolicy);
 
     return yield* upload.pipe(
       Effect.tap(() => Effect.sync(() => spinner.stop("Usage uploaded"))),
@@ -359,15 +362,38 @@ function uploadUsageReports({
 }
 
 function uploadUsageReportsOnce(
-  input: Pick<UploadUsageReportsOptions, "auth" | "device" | "rawReports">,
+  input: Pick<UploadUsageReportsOptions, "auth" | "device" | "rawReports" | "sourceStats">,
   uploadPolicy: UploadRetryPolicy | undefined,
 ) {
   const upload = () =>
-    input.auth.client.usage.ingest({
-      payload: {
-        device: input.device,
-        reports: input.rawReports,
-      },
+    Effect.gen(function* () {
+      const reports = input.rawReports.flatMap(chunkRawUsageReport);
+      const batches = reports.length === 0 ? [[]] : reports.map((report) => [report]);
+      let received = 0;
+      let syncedAt = "";
+      let upserted = 0;
+
+      for (const batch of batches) {
+        const response = yield* input.auth.client.usage.ingest({
+          payload: { device: input.device, reports: batch },
+        });
+        received += response.received;
+        syncedAt = response.syncedAt;
+        upserted += response.upserted;
+      }
+
+      if (input.sourceStats !== undefined) {
+        const response = yield* input.auth.client.usage.sync({
+          payload: {
+            days: [],
+            device: input.device,
+            sourceStats: input.sourceStats,
+          },
+        });
+        syncedAt = response.syncedAt;
+      }
+
+      return { received, syncedAt, upserted };
     });
 
   if (uploadPolicy === undefined) {
@@ -375,6 +401,34 @@ function uploadUsageReportsOnce(
   }
 
   return uploadWithRetry(upload, uploadPolicy);
+}
+
+const SESSION_REPORT_CHUNK_SIZE = 5_000;
+
+function chunkRawUsageReport(report: RawUsageReportInput): RawUsageReportInput[] {
+  if (report.reportKind !== "session") {
+    return [report];
+  }
+
+  const payload = report.payload;
+  if (typeof payload !== "object" || payload === null) {
+    return [report];
+  }
+
+  const sessions = (payload as { sessions?: unknown }).sessions;
+  if (!Array.isArray(sessions) || sessions.length <= SESSION_REPORT_CHUNK_SIZE) {
+    return [report];
+  }
+
+  const chunks: RawUsageReportInput[] = [];
+  for (let offset = 0; offset < sessions.length; offset += SESSION_REPORT_CHUNK_SIZE) {
+    chunks.push({
+      ...report,
+      payload: { ...payload, sessions: sessions.slice(offset, offset + SESSION_REPORT_CHUNK_SIZE) },
+    });
+  }
+
+  return chunks;
 }
 
 function uploadWithRetry<A, E, R>(


### PR DESCRIPTION
I hit this while trying to sync Codex usage from Windows: `ccusage` itself could see the data, but `tokenmaxxing sync` reported Codex as skipped.

The problem was the way the CLI starts `ccusage`. On Windows, `bunx` was not available in the setup I tested, and the npm fallback used the shell-style `npx` name even though the process is launched directly. That meant the child process failed before `ccusage` ran, and sync turned that into "no data".

This changes the runner to:

- call `bun x ccusage@^20 ...` instead of `bunx`
- use `npx.cmd` for the Windows npm fallback
- keep the existing `npx` fallback elsewhere
- add a small test for the Windows command selection

I also verified the compiled Windows runner with external `bun` removed from `PATH`, so npm-only installs still fall back through `npx.cmd`.

Once that exposed the full Codex history, bootstrap hit a second issue during upload. The complete session report was about 54 MB for roughly 68,000 sessions, and production returned HTTP 503 for the single `/usage/ingest` request. A dated upload without the full session report succeeded, which narrowed the failure to the request size rather than login or connectivity.

This also changes usage upload to:

- split large session reports into chunks of at most 5,000 sessions
- upload each chunk separately through the existing ingest endpoint
- preserve all raw session records
- restore the true aggregate session count through the existing structured sync endpoint after the chunks land

This does not require an API or schema change.

Checks:

- `bun run --cwd apps/cli test -- src/ccusage/runner.test.ts src/ccusage/aggregate.test.ts src/commands/sync.test.ts`
- `bun run --cwd apps/cli test -- src/commands/sync.test.ts`
- `bun run --cwd apps/cli typecheck`
- `bun run fmt -- apps/cli/src/ccusage/runner.ts apps/cli/src/ccusage/runner.test.ts apps/cli/src/commands/sync.ts apps/cli/src/commands/sync.test.ts`
- `bun apps\cli\src\index.ts sync --dry-run --json --sources codex --since 2026-07-01`
- compiled Windows runner dry-run with external `bun` removed from `PATH`
- full production upload with `bun apps\cli\src\index.ts sync --json --sources codex` (`68,671` sessions, `582` rows, `upserted: 582`)
- full pre-commit test fails on this Windows machine in existing service scheduler tests that expect POSIX-style paths/date behavior, and current upstream Alchemy types also fail the repo-wide typecheck; the focused CLI checks and production sync pass
