### PR TITLE
fix(cli): scrub path-derived identifiers from session reports before upload

### DIFF
--- a/apps/cli/src/ccusage/sanitize.test.ts
+++ b/apps/cli/src/ccusage/sanitize.test.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { sanitizeSessionReport } from "./sanitize";
+
+/**
+ * Mirrors `ccusage claude session --json` v20: `sessionId` and `projectPath`
+ * both encode the local project directory path.
+ */
+const claudeSession = {
+  sessionId: "-Users-alexandru-repos-tokenmaxxing",
+  projectPath: "-Users-alexandru-repos-tokenmaxxing",
+  inputTokens: 355_038,
+  outputTokens: 1_438_433,
+  cacheCreationTokens: 6_058_989,
+  cacheReadTokens: 652_827_808,
+  totalTokens: 660_680_268,
+  totalCost: 851.14,
+  lastActivity: "2026-06-10",
+  versions: ["1.0.24"],
+  modelsUsed: ["claude-haiku-4-5-20251001"],
+  modelBreakdowns: [
+    {
+      modelName: "claude-haiku-4-5-20251001",
+      inputTokens: 6_637,
+      outputTokens: 327_616,
+      cacheCreationTokens: 2_865_086,
+      cacheReadTokens: 46_241_604,
+      cost: 9.85,
+      // Hypothetical future field: must be dropped, not passed through.
+      transcriptPath: "/Users/alexandru/.claude/projects/foo/transcript.jsonl",
+    },
+  ],
+};
+
+function expectedHash(identifier: string): string {
+  return createHash("sha256").update(identifier).digest("hex").slice(0, 16);
+}
+
+describe("sanitizeSessionReport", () => {
+  it("keeps only allowlisted aggregates and hashes the path-derived sessionId", () => {
+    const report = sanitizeSessionReport({ sessions: [claudeSession] });
+
+    expect(report.sessions).toHaveLength(1);
+    expect(report.sessions[0]).toEqual({
+      cacheCreationTokens: 6_058_989,
+      cacheReadTokens: 652_827_808,
+      inputTokens: 355_038,
+      lastActivity: "2026-06-10",
+      modelBreakdowns: [
+        {
+          cacheCreationTokens: 2_865_086,
+          cacheReadTokens: 46_241_604,
+          cost: 9.85,
+          inputTokens: 6_637,
+          modelName: "claude-haiku-4-5-20251001",
+          outputTokens: 327_616,
+        },
+      ],
+      modelsUsed: ["claude-haiku-4-5-20251001"],
+      outputTokens: 1_438_433,
+      sessionId: expectedHash("-Users-alexandru-repos-tokenmaxxing"),
+      totalCost: 851.14,
+      totalTokens: 660_680_268,
+      versions: ["1.0.24"],
+    });
+  });
+
+  it("leaves no path substrings anywhere in the serialized payload", () => {
+    const serialized = JSON.stringify(sanitizeSessionReport({ sessions: [claudeSession] }));
+
+    expect(serialized).not.toContain("Users");
+    expect(serialized).not.toContain("alexandru");
+    expect(serialized).not.toContain("tokenmaxxing");
+    expect(serialized).not.toContain("projectPath");
+    expect(serialized).not.toContain("transcriptPath");
+  });
+
+  it("replaces the sessionId with a non-reversible fixed-length hex hash", () => {
+    const report = sanitizeSessionReport({ sessions: [claudeSession] });
+    const sessionId = report.sessions[0]?.sessionId;
+
+    expect(sessionId).toMatch(/^[0-9a-f]{16}$/);
+    expect(sessionId).not.toBe(claudeSession.sessionId);
+  });
+
+  it("hashes codex-style sessionFile identifiers into sessionId", () => {
+    const report = sanitizeSessionReport({
+      sessions: [
+        {
+          sessionFile: "rollout-2026-02-09T12-05-23",
+          totalTokens: 5_000,
+          costUSD: 0.5,
+        },
+      ],
+    });
+
+    expect(report.sessions[0]).toEqual({
+      costUSD: 0.5,
+      sessionId: expectedHash("rollout-2026-02-09T12-05-23"),
+      totalTokens: 5_000,
+    });
+  });
+
+  it("drops unknown fields, non-record entries, and path-shaped timestamps", () => {
+    const report = sanitizeSessionReport({
+      sessions: [
+        {
+          sessionId: "abc",
+          lastActivity: "/Users/alexandru/repos",
+          project: "secret-client-project",
+          cwd: "/Users/alexandru/repos/secret",
+          inputTokens: Number.NaN,
+          outputTokens: 42,
+        },
+        "not-a-record",
+        null,
+      ],
+    });
+
+    expect(report.sessions).toHaveLength(1);
+    expect(report.sessions[0]).toEqual({
+      outputTokens: 42,
+      sessionId: expectedHash("abc"),
+    });
+  });
+});

--- a/apps/cli/src/ccusage/sanitize.ts
+++ b/apps/cli/src/ccusage/sanitize.ts
@@ -1,0 +1,166 @@
+import { createHash } from "node:crypto";
+
+import type { CcusageSessionReport } from "./schema";
+
+/**
+ * Privacy scrubbing for `ccusage <source> session --json` payloads before
+ * they are uploaded as raw reports. Session entries carry identifiers derived
+ * from local project directory paths (claude encodes `~/.claude/projects`
+ * directory names into `sessionId`/`projectPath`, codex exposes rollout file
+ * names via `sessionFile`), and the privacy policy promises that file paths
+ * and project names never leave the machine.
+ *
+ * The sanitizer is a strict allowlist: only aggregate token counts, costs,
+ * date-shaped timestamps, model names, and version strings survive. The
+ * session identifier is replaced with a truncated SHA-256 hash so the server
+ * can still deduplicate and correlate sessions without learning path-derived
+ * names. Every field not on the allowlist is dropped, never passed through.
+ */
+
+const SESSION_ID_HASH_LENGTH = 16;
+
+/** Aggregate counters that are safe on sessions and per-model breakdowns. */
+const NUMERIC_FIELDS = [
+  "cacheCreationTokens",
+  "cacheReadTokens",
+  "cost",
+  "costUSD",
+  "inputTokens",
+  "outputTokens",
+  "totalCost",
+  "totalTokens",
+] as const;
+
+type NumericField = (typeof NUMERIC_FIELDS)[number];
+
+/** Identifier fields hashed into `sessionId`; first present value wins. */
+const SESSION_ID_FIELDS = ["sessionId", "sessionFile"] as const;
+
+/** YYYY-MM-DD with an optional time suffix — anything else could be a path. */
+const DATE_LIKE = /^\d{4}-\d{2}-\d{2}([T ][0-9:.TZ+-]*)?$/;
+
+type SanitizedNumericFields = Partial<Record<NumericField, number>>;
+
+interface SanitizedCcusageModelBreakdown extends SanitizedNumericFields {
+  modelName: string;
+}
+
+interface SanitizedCcusageSession extends SanitizedNumericFields {
+  lastActivity?: string;
+  modelBreakdowns?: SanitizedCcusageModelBreakdown[];
+  modelsUsed?: string[];
+  sessionId?: string;
+  versions?: string[];
+}
+
+interface SanitizedCcusageSessionReport {
+  sessions: SanitizedCcusageSession[];
+}
+
+function sanitizeSessionReport(report: CcusageSessionReport): SanitizedCcusageSessionReport {
+  return {
+    sessions: report.sessions.flatMap((session) => {
+      const sanitized = sanitizeSession(session);
+      return sanitized === undefined ? [] : [sanitized];
+    }),
+  };
+}
+
+function sanitizeSession(session: unknown): SanitizedCcusageSession | undefined {
+  if (!isRecord(session)) {
+    return undefined;
+  }
+
+  const sanitized: SanitizedCcusageSession = pickNumericFields(session);
+
+  const identifier = sessionIdentifier(session);
+  if (identifier !== undefined) {
+    sanitized.sessionId = hashSessionId(identifier);
+  }
+
+  const lastActivity = session["lastActivity"];
+  if (typeof lastActivity === "string" && DATE_LIKE.test(lastActivity)) {
+    sanitized.lastActivity = lastActivity;
+  }
+
+  const modelsUsed = stringArray(session["modelsUsed"]);
+  if (modelsUsed !== undefined) {
+    sanitized.modelsUsed = modelsUsed;
+  }
+
+  const versions = stringArray(session["versions"]);
+  if (versions !== undefined) {
+    sanitized.versions = versions;
+  }
+
+  const modelBreakdowns = sanitizeModelBreakdowns(session["modelBreakdowns"]);
+  if (modelBreakdowns !== undefined) {
+    sanitized.modelBreakdowns = modelBreakdowns;
+  }
+
+  return sanitized;
+}
+
+function sanitizeModelBreakdowns(value: unknown): SanitizedCcusageModelBreakdown[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const breakdowns = value.flatMap((entry): SanitizedCcusageModelBreakdown[] => {
+    if (!isRecord(entry) || typeof entry["modelName"] !== "string") {
+      return [];
+    }
+
+    return [{ ...pickNumericFields(entry), modelName: entry["modelName"] }];
+  });
+
+  return breakdowns.length === 0 ? undefined : breakdowns;
+}
+
+function sessionIdentifier(session: Record<string, unknown>): string | undefined {
+  for (const field of SESSION_ID_FIELDS) {
+    const value = session[field];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function hashSessionId(identifier: string): string {
+  return createHash("sha256").update(identifier).digest("hex").slice(0, SESSION_ID_HASH_LENGTH);
+}
+
+function pickNumericFields(record: Record<string, unknown>): SanitizedNumericFields {
+  const picked: SanitizedNumericFields = {};
+  for (const field of NUMERIC_FIELDS) {
+    const value = record[field];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      picked[field] = value;
+    }
+  }
+
+  return picked;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const strings = value.filter((entry): entry is string => typeof entry === "string");
+  return strings.length === 0 ? undefined : strings;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export { sanitizeSessionReport };
+
+export type {
+  SanitizedCcusageModelBreakdown,
+  SanitizedCcusageSession,
+  SanitizedCcusageSessionReport,
+};

--- a/apps/cli/src/ccusage/schema.ts
+++ b/apps/cli/src/ccusage/schema.ts
@@ -57,6 +57,12 @@ const CcusageDailyReport = Schema.Struct({
 
 type CcusageDailyReport = typeof CcusageDailyReport.Type;
 
+/**
+ * Session entries stay `Unknown` at decode time because each source emits a
+ * different dialect and only the count is read locally. They are NEVER
+ * uploaded as-is: `sanitizeSessionReport` (./sanitize.ts) reduces them to an
+ * allowlisted aggregate shape with a hashed session identifier first.
+ */
 const CcusageSessionReport = Schema.Struct({
   sessions: Schema.Array(Schema.Unknown),
 });

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -17,6 +17,7 @@ import {
   runCcusageSessionReport,
   sessionCcusageCommand,
 } from "../ccusage/runner";
+import { sanitizeSessionReport } from "../ccusage/sanitize";
 import { DEFAULT_SOURCE_NAMES, resolveSources } from "../ccusage/sources";
 import {
   ApiClientService,
@@ -278,7 +279,9 @@ function syncProgram(options: SyncProgramOptions) {
       if (options.since === undefined && Option.isSome(sessionReport)) {
         rawReports.push({
           command: sessionCcusageCommand(source),
-          payload: sessionReport.value,
+          // Session entries embed path-derived identifiers (project dirs,
+          // rollout file names); only allowlisted aggregates may upload.
+          payload: sanitizeSessionReport(sessionReport.value),
           reportKind: "session",
           source: source.source,
         });


### PR DESCRIPTION
tokenmaxxing sync uploaded the entire ccusage session JSON as a raw report, including session IDs derived from local project directory names and projectPath fields — contradicting the privacy policy's promise that file paths and project names never leave the machine.

Session payloads now pass through a strict allowlist sanitizer before entering rawReports: only token counts, costs, date-shaped timestamps, model names/breakdowns, and version strings survive; the session identifier is replaced with a truncated SHA-256 hash so the server can still deduplicate sessions; every unknown field is dropped.