### PR TITLE
[codex] Fix account linking leaderboard merges

### DIFF
--- a/apps/api/src/auth/service.test.ts
+++ b/apps/api/src/auth/service.test.ts
@@ -3,7 +3,6 @@ import { Effect } from "effect";
 import { Option } from "effect";
 
 import {
-  AccountLinkConflict,
   AuthRepository,
   makeAuthService,
   type CurrentUser,
@@ -117,7 +116,7 @@ describe("AuthService provider linking", () => {
     expect(store.accounts.get(accountKey("google", "google_123"))?.userId).toBe(user.id);
   });
 
-  it("rejects linking a provider account that belongs to another user", async () => {
+  it("merges a provider account owned by another profile into the current session user", async () => {
     const { service, store } = await makeTestAuth();
     const current = currentUser({ id: "current", login: "current" });
     const other = currentUser({ id: "other", login: "other" });
@@ -128,13 +127,15 @@ describe("AuthService provider linking", () => {
       userId: other.id,
     });
 
-    await expect(
-      runAuth(
-        service.signInWithProvider(googleProfile({ email: "other@example.com" }), {
-          currentUser: current,
-        }),
-      ),
-    ).rejects.toBeInstanceOf(AccountLinkConflict);
+    const result = await runAuth(
+      service.signInWithProvider(googleProfile({ email: "other@example.com" }), {
+        currentUser: current,
+      }),
+    );
+
+    expect(result.user.id).toBe(current.id);
+    expect(store.users.has(other.id)).toBe(false);
+    expect(store.accounts.get(accountKey("google", "google_123"))?.userId).toBe(current.id);
   });
 
   it("merges an existing provider duplicate into the current session user", async () => {

--- a/apps/api/src/auth/service.ts
+++ b/apps/api/src/auth/service.ts
@@ -1,5 +1,5 @@
 import { Context } from "effect";
-import { Data, Effect } from "effect";
+import { Effect } from "effect";
 import { Option } from "effect";
 
 import type { DatabaseError } from "../database";
@@ -37,17 +37,13 @@ interface UserAccountSummary {
 
 const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
-class AccountLinkConflict extends Data.TaggedError("AccountLinkConflict")<{
-  readonly provider: OAuthProviderId;
-}> {}
-
 interface AuthServiceShape {
   /** Resolves or links a provider identity, then mints a browser session.
    * Returns the RAW token (stored hashed). */
   signInWithProvider(
     profile: OAuthProfile,
     options?: { currentUser?: CurrentUser | undefined },
-  ): Effect.Effect<{ token: string; user: CurrentUser }, AccountLinkConflict | DatabaseError, any>;
+  ): Effect.Effect<{ token: string; user: CurrentUser }, DatabaseError, any>;
   resolveSession(rawToken: string): Effect.Effect<Option.Option<CurrentUser>, DatabaseError, any>;
   signOut(rawToken: string): Effect.Effect<void, DatabaseError, any>;
   listAccounts(userId: string): Effect.Effect<UserAccountSummary[], DatabaseError, any>;
@@ -119,15 +115,9 @@ const makeAuthService = Effect.fn("makeAuthService")(function* () {
         );
         if (Option.isSome(existing)) {
           if (options?.currentUser !== undefined && options.currentUser.id !== existing.value.id) {
-            const canMerge = yield* canMergeVerifiedEmailConflict(
-              profile,
-              existing.value,
-              options.currentUser,
-            );
-            if (!canMerge) {
-              return yield* Effect.fail(new AccountLinkConflict({ provider: profile.provider }));
-            }
-
+            // A signed-in session plus a fresh OAuth callback proves control
+            // of both profiles; merge the existing provider profile into the
+            // current profile so usage follows the connected account.
             yield* repository.mergeUsers({
               sourceUserId: existing.value.id,
               targetUserId: options.currentUser.id,
@@ -188,19 +178,6 @@ const makeAuthService = Effect.fn("makeAuthService")(function* () {
     return Effect.gen(function* () {
       const users = yield* repository.findUsersByVerifiedEmail(profile.email!);
       return [...new Map(users.map((user) => [user.id, user])).values()];
-    });
-  }
-
-  function canMergeVerifiedEmailConflict(
-    profile: OAuthProfile,
-    source: CurrentUser,
-    target: CurrentUser,
-  ) {
-    return Effect.gen(function* () {
-      const users = yield* verifiedEmailUsers(profile);
-      const userIds = new Set(users.map((user) => user.id));
-
-      return userIds.has(source.id) && userIds.has(target.id);
     });
   }
 
@@ -281,7 +258,7 @@ function slugifyLogin(value: string): string {
   return slug.length === 0 ? "user" : slug;
 }
 
-export { AccountLinkConflict, AuthRepository, AuthService, makeAuthService };
+export { AuthRepository, AuthService, makeAuthService };
 
 export type {
   AuthRepositoryShape,

--- a/apps/api/src/http/routes/oauth.ts
+++ b/apps/api/src/http/routes/oauth.ts
@@ -95,9 +95,6 @@ function oauthCallbackRoute(provider: OAuthProviderId) {
         const signedIn = yield* auth.signInWithProvider(profile, options);
         return { _tag: "success" as const, ...signedIn };
       }).pipe(
-        Effect.catchTag("AccountLinkConflict", () =>
-          Effect.succeed({ _tag: "conflict" as const, provider }),
-        ),
         Effect.catchCause((cause) =>
           Effect.sync(() => {
             console.error(`${provider} oauth callback failed`, String(cause).slice(0, 500));
@@ -107,16 +104,6 @@ function oauthCallbackRoute(provider: OAuthProviderId) {
       );
 
       switch (result._tag) {
-        case "conflict":
-          return HttpServerResponse.jsonUnsafe(
-            {
-              error: {
-                code: "oauth_account_conflict",
-                message: `That ${providerLabel(provider)} account is already connected to another tokenmaxxing profile.`,
-              },
-            },
-            { status: 409 },
-          );
         case "failed":
           return HttpServerResponse.jsonUnsafe(
             {

--- a/apps/www/src/components/oauth-providers.test.ts
+++ b/apps/www/src/components/oauth-providers.test.ts
@@ -51,4 +51,24 @@ describe("oauthProviderLinks", () => {
     expect(githubUrl.pathname).toBe("/auth/github/start");
     expect(githubUrl.searchParams.get("redirect")).toBe("/login/cli?code=ABCD-1234");
   });
+
+  it("builds account connection links", () => {
+    const links = oauthProviderLinks({
+      action: "connect",
+      providers: ["google"],
+      redirect: "/settings",
+    });
+    const [google] = links;
+    if (google === undefined) {
+      throw new Error("expected Google provider");
+    }
+
+    const googleUrl = new URL(google.href);
+
+    expect(links).toHaveLength(1);
+    expect(google.id).toBe("google");
+    expect(google.label).toBe("Connect Google");
+    expect(googleUrl.pathname).toBe("/auth/google/start");
+    expect(googleUrl.searchParams.get("redirect")).toBe("/settings");
+  });
 });

--- a/apps/www/src/components/oauth-providers.tsx
+++ b/apps/www/src/components/oauth-providers.tsx
@@ -3,6 +3,7 @@ import { cn } from "../lib/cn";
 import { resolveApiUrl } from "../lib/config";
 
 type OAuthProviderId = "github" | "google";
+type OAuthProviderAction = "connect" | "continue";
 
 const OAUTH_PROVIDERS = [
   { id: "github", name: "GitHub" },
@@ -18,6 +19,7 @@ interface OAuthProviderLink {
 }
 
 interface OAuthProviderOptions {
+  action?: OAuthProviderAction | undefined;
   providers?: readonly OAuthProviderId[] | undefined;
   redirect?: string | undefined;
 }
@@ -57,10 +59,15 @@ function GoogleMark({ className }: { className?: string }) {
   );
 }
 
-function OAuthProviderButtons({ className, providers, redirect }: OAuthProviderButtonsProps) {
+function OAuthProviderButtons({
+  action,
+  className,
+  providers,
+  redirect,
+}: OAuthProviderButtonsProps) {
   return (
     <div className={cn("flex w-full flex-col gap-3", className)}>
-      {oauthProviderLinks({ providers, redirect }).map((provider) => (
+      {oauthProviderLinks({ action, providers, redirect }).map((provider) => (
         <a
           className={buttonClassName({ variant: "primary", size: "md", fullWidth: true })}
           href={provider.href}
@@ -75,6 +82,7 @@ function OAuthProviderButtons({ className, providers, redirect }: OAuthProviderB
 }
 
 function oauthProviderLinks({
+  action = "continue",
   providers,
   redirect,
 }: OAuthProviderOptions = {}): OAuthProviderLink[] {
@@ -92,9 +100,18 @@ function oauthProviderLinks({
     return {
       href: url.toString(),
       id: provider.id,
-      label: `Continue with ${provider.name}`,
+      label: oauthProviderActionLabel(action, provider.name),
     };
   });
+}
+
+function oauthProviderActionLabel(action: OAuthProviderAction, providerName: string): string {
+  switch (action) {
+    case "connect":
+      return `Connect ${providerName}`;
+    case "continue":
+      return `Continue with ${providerName}`;
+  }
 }
 
 function providerIcon(provider: OAuthProviderId) {
@@ -112,4 +129,4 @@ function oauthProviderLabel(provider: OAuthProviderId): string {
 
 export { LOGIN_OAUTH_PROVIDERS, OAuthProviderButtons, oauthProviderLabel, oauthProviderLinks };
 
-export type { OAuthProviderId };
+export type { OAuthProviderAction, OAuthProviderId };

--- a/apps/www/src/routes/settings.tsx
+++ b/apps/www/src/routes/settings.tsx
@@ -1,15 +1,28 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { DeviceSummary } from "@tokenmaxxing/api-contract";
-import { Key, Laptop } from "@phosphor-icons/react/ssr";
+import { DeviceSummary, UserAccountSummary } from "@tokenmaxxing/api-contract";
+import { Key, Laptop, LinkSimple } from "@phosphor-icons/react/ssr";
 
+import {
+  OAuthProviderButtons,
+  oauthProviderLabel,
+  type OAuthProviderId,
+} from "../components/oauth-providers";
+import { Avatar } from "../components/ui/avatar";
 import { Button } from "../components/ui/button";
 import { Code } from "../components/ui/code";
 import { errorMessage, isApiError, runApi } from "../lib/api";
-import { devicesQueryOptions, meQueryOptions, tokensQueryOptions } from "../lib/queries";
+import {
+  accountsQueryOptions,
+  devicesQueryOptions,
+  meQueryOptions,
+  tokensQueryOptions,
+} from "../lib/queries";
 
 const SETTINGS_PATH = "/settings";
+const ACCOUNT_PROVIDERS = ["github", "google"] as const satisfies readonly OAuthProviderId[];
 
+type Account = typeof UserAccountSummary.Type;
 type Device = typeof DeviceSummary.Type;
 type DeviceDeleteInvalidationKey = readonly unknown[];
 
@@ -18,6 +31,7 @@ const Route = createFileRoute("/settings")({
     try {
       await context.queryClient.ensureQueryData(meQueryOptions);
       await Promise.all([
+        context.queryClient.ensureQueryData(accountsQueryOptions),
         context.queryClient.ensureQueryData(devicesQueryOptions),
         context.queryClient.ensureQueryData(tokensQueryOptions),
       ]);
@@ -44,10 +58,76 @@ function SettingsPage() {
   return (
     <div className="flex flex-col gap-10 px-4 py-8">
       <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+      <AccountsSection />
       <DevicesSection login={me.user.login} />
       <TokensSection />
     </div>
   );
+}
+
+function AccountsSection() {
+  const { data } = useSuspenseQuery(accountsQueryOptions);
+  const connectedProviders = new Set(data.accounts.map((account) => account.provider));
+  const missingProviders = ACCOUNT_PROVIDERS.filter(
+    (provider) => !connectedProviders.has(provider),
+  );
+
+  return (
+    <section>
+      <h2 className="flex items-center gap-2 text-lg font-medium">
+        <LinkSimple className="size-4" /> Connected accounts
+      </h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Linked accounts share one public profile; existing usage, devices, and CLI tokens move here
+        when profiles merge.
+      </p>
+      <div className="-mx-4 mt-4 overflow-hidden border-y border-border">
+        <table className="w-full text-sm">
+          <tbody>
+            {data.accounts.map((account) => (
+              <tr
+                className="border-b border-border last:border-b-0"
+                key={`${account.provider}:${account.providerAccountId}`}
+              >
+                <td className="p-3">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <Avatar alt={accountLabel(account)} size="sm" src={account.avatarUrl} />
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{accountLabel(account)}</p>
+                      <p className="truncate text-muted-foreground">{accountSecondary(account)}</p>
+                    </div>
+                  </div>
+                </td>
+                <td className="p-3 text-right text-muted-foreground">
+                  {oauthProviderLabel(account.provider)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {missingProviders.length > 0 ? (
+        <OAuthProviderButtons
+          action="connect"
+          className="mt-4 max-w-sm"
+          providers={missingProviders}
+          redirect={SETTINGS_PATH}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function accountLabel(account: Account): string {
+  return account.login ?? account.name ?? account.email ?? oauthProviderLabel(account.provider);
+}
+
+function accountSecondary(account: Account): string {
+  if (account.email !== null) {
+    return account.emailVerified ? `${account.email} verified` : account.email;
+  }
+
+  return account.providerAccountId;
 }
 
 function DevicesSection({ login }: { login: string }) {


### PR DESCRIPTION
## Summary
- allow a signed-in OAuth callback for an existing provider profile to merge that profile into the current user
- remove the now-unreachable OAuth account-conflict response path
- add a Connected accounts section in settings with connect buttons for missing providers

## Root Cause
The leaderboard aggregates by `usage_days.user_id`, and `mergeUsers` already re-homes usage rows, devices, and CLI tokens. However, linking a provider account that already belonged to another tokenmaxxing profile was rejected unless the verified email overlapped, so owned accounts with different emails could not be merged into one leaderboard identity. The settings page also did not expose `/me/accounts`, making account linking hard to discover.

## Validation
- `npx -y bun@1.3.14 run typecheck`
- `npx -y bun@1.3.14 run fmt`
- `npx -y bun@1.3.14 run lint`
- `npx -y bun@1.3.14 run test`