### PR TITLE
Add Grok and Antigravity usage sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 .env.*
 !.env.example

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="ASK" />
+    <option name="description" value="" />
+    <option name="applicationTheme" value="default" />
+    <option name="iconsTheme" value="default" />
+    <option name="button1Title" value="" />
+    <option name="button1Url" value="" />
+    <option name="button2Title" value="" />
+    <option name="button2Url" value="" />
+    <option name="customApplicationId" value="" />
+  </component>
+</project>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="-33b304b8:1962ba2318a:-7ffe" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/tokenmaxxing.iml" filepath="$PROJECT_DIR$/.idea/tokenmaxxing.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/tokenmaxxing.iml
+++ b/.idea/tokenmaxxing.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # tokenmaxxing
 
 The social leaderboard for LLM token usage. Sync your local agent usage
-(Claude Code, Codex, OpenCode, Gemini CLI, Copilot CLI), climb the board at
+(Claude Code, Codex, OpenCode, Gemini CLI, Copilot CLI, Kimi, Grok CLI,
+Antigravity), climb the board at
 [tokenmaxxing.sh](https://tokenmaxxing.sh).
 
 Built on [ccusage](https://github.com/ryoppippi/ccusage) for local usage
-parsing, [Effect](https://effect.website) v4 end to end, and deployed to
+parsing (plus native collectors for Grok CLI and Antigravity), [Effect](https://effect.website) v4 end to end, and deployed to
 Cloudflare (Workers + D1) with [Alchemy](https://alchemy.run) v2.
 
 ## Quick start

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -2,9 +2,10 @@
 
 CLI for [tokenmaxxing](https://tokenmaxxing.sh) — the social leaderboard
 for LLM token usage. Parses your local agent usage (Claude Code, Codex,
-OpenCode, Gemini CLI, Copilot CLI) via
-[ccusage](https://github.com/ryoppippi/ccusage) and pushes daily aggregates
-to your public profile.
+OpenCode, Gemini CLI, Copilot CLI, Kimi) via
+[ccusage](https://github.com/ryoppippi/ccusage), reads Grok CLI and
+Antigravity (`agy`) usage from their local data files, and pushes daily
+aggregates to your public profile.
 
 ## Usage
 

--- a/apps/cli/src/ccusage/runner.ts
+++ b/apps/cli/src/ccusage/runner.ts
@@ -4,7 +4,6 @@ import { Data, Effect, Option } from "effect";
 
 import type { CcusageDailyReport, CcusageSessionReport } from "./schema";
 import { decodeDailyReport, decodeSessionReport } from "./schema";
-import type { CcusageSource } from "./sources";
 
 /**
  * Shells out to `bunx ccusage@^20.0.17 <source> daily --json --breakdown` (npx
@@ -12,6 +11,14 @@ import type { CcusageSource } from "./sources";
  * installed, or has no local data resolves to none — one broken agent must
  * never abort the whole sync.
  */
+
+/** Minimal shape of a ccusage-backed source (see sources.ts). */
+interface CcusageSource {
+  /** The source tag stored server-side and shown on profiles. */
+  source: string;
+  /** ccusage subcommand. */
+  subcommand: string;
+}
 
 const CCUSAGE_SPEC = "ccusage@^20.0.17";
 const RUN_TIMEOUT_MS = 180_000;

--- a/apps/cli/src/ccusage/sources.test.ts
+++ b/apps/cli/src/ccusage/sources.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SOURCE_NAMES, resolveSources } from "./sources";
+
+describe("resolveSources", () => {
+  it("resolves every default source", () => {
+    const { invalid, sources } = resolveSources(DEFAULT_SOURCE_NAMES);
+
+    expect(invalid).toEqual([]);
+    expect(sources.map((entry) => entry.source)).toEqual([
+      "claude",
+      "codex",
+      "opencode",
+      "gemini",
+      "copilot",
+      "kimi",
+      "grok",
+      "antigravity",
+    ]);
+  });
+
+  it("maps ccusage sources to their subcommand", () => {
+    const { sources } = resolveSources(["kimi"]);
+
+    expect(sources).toEqual([{ collector: "ccusage", source: "kimi", subcommand: "kimi" }]);
+  });
+
+  it("marks grok and antigravity as local collectors", () => {
+    const { sources } = resolveSources(["grok", "antigravity"]);
+
+    expect(sources).toEqual([
+      { collector: "grok", source: "grok" },
+      { collector: "antigravity", source: "antigravity" },
+    ]);
+  });
+
+  it("accepts agy as an alias for antigravity", () => {
+    const { invalid, sources } = resolveSources(["agy"]);
+
+    expect(invalid).toEqual([]);
+    expect(sources).toEqual([{ collector: "antigravity", source: "antigravity" }]);
+  });
+
+  it("dedupes aliases and canonical names", () => {
+    const { sources } = resolveSources(["agy", "antigravity", " AGY "]);
+
+    expect(sources).toHaveLength(1);
+  });
+
+  it("collects unknown names without dropping valid ones", () => {
+    const { invalid, sources } = resolveSources(["grok", "not-a-tool"]);
+
+    expect(invalid).toEqual(["not-a-tool"]);
+    expect(sources.map((entry) => entry.source)).toEqual(["grok"]);
+  });
+});

--- a/apps/cli/src/ccusage/sources.ts
+++ b/apps/cli/src/ccusage/sources.ts
@@ -1,36 +1,60 @@
 /**
- * Per-source invocation strategy. Every supported agent maps to one focused
- * `ccusage <subcommand> daily` run; rows get tagged with `source` by the
- * aggregator. The unified `ccusage daily` is never used — it mixes agents
- * into untagged rows.
+ * Per-source collection strategy. ccusage-backed agents map to one focused
+ * `ccusage <subcommand> daily` run; grok and antigravity have no ccusage
+ * support and are read from their local data files directly (see
+ * ../local). Rows get tagged with `source` by the aggregator. The unified
+ * `ccusage daily` is never used — it mixes agents into untagged rows.
+ *
+ * kimi ships as a ccusage subcommand already — if ccusage adds grok or
+ * antigravity later, those can flip to ccusage collectors too.
  */
 
-interface CcusageSource {
+interface CcusageUsageSource {
+  collector: "ccusage";
+  /** The source tag stored server-side and shown on profiles. */
+  source: string;
   /** ccusage subcommand. */
   subcommand: string;
+}
+
+interface LocalUsageSource {
+  collector: "antigravity" | "grok";
   /** The source tag stored server-side and shown on profiles. */
   source: string;
 }
 
-const CCUSAGE_SOURCES: readonly CcusageSource[] = [
-  { source: "claude", subcommand: "claude" },
-  { source: "codex", subcommand: "codex" },
-  { source: "opencode", subcommand: "opencode" },
-  { source: "gemini", subcommand: "gemini" },
-  { source: "copilot", subcommand: "copilot" },
+/** How a source's local usage gets collected, and what it is called. */
+type UsageSource = CcusageUsageSource | LocalUsageSource;
+
+const USAGE_SOURCES: readonly UsageSource[] = [
+  { collector: "ccusage", source: "claude", subcommand: "claude" },
+  { collector: "ccusage", source: "codex", subcommand: "codex" },
+  { collector: "ccusage", source: "opencode", subcommand: "opencode" },
+  { collector: "ccusage", source: "gemini", subcommand: "gemini" },
+  { collector: "ccusage", source: "copilot", subcommand: "copilot" },
+  { collector: "ccusage", source: "kimi", subcommand: "kimi" },
+  { collector: "grok", source: "grok" },
+  { collector: "antigravity", source: "antigravity" },
 ];
 
-const DEFAULT_SOURCE_NAMES = CCUSAGE_SOURCES.map((entry) => entry.source);
+/** Alternate spellings accepted by --sources, mapped to the canonical tag. */
+const SOURCE_ALIASES: Readonly<Record<string, string>> = {
+  agy: "antigravity",
+};
+
+const DEFAULT_SOURCE_NAMES = USAGE_SOURCES.map((entry) => entry.source);
 
 function resolveSources(names: readonly string[]): {
   invalid: string[];
-  sources: CcusageSource[];
+  sources: UsageSource[];
 } {
-  const bySource = new Map(CCUSAGE_SOURCES.map((entry) => [entry.source, entry]));
-  const sources: CcusageSource[] = [];
+  const bySource = new Map(USAGE_SOURCES.map((entry) => [entry.source, entry]));
+  const sources: UsageSource[] = [];
   const invalid: string[] = [];
   for (const name of names) {
-    const entry = bySource.get(name.trim().toLowerCase());
+    const normalized = name.trim().toLowerCase();
+    const canonical = SOURCE_ALIASES[normalized] ?? normalized;
+    const entry = bySource.get(canonical);
     if (entry === undefined) {
       invalid.push(name);
     } else if (!sources.includes(entry)) {
@@ -43,4 +67,4 @@ function resolveSources(names: readonly string[]): {
 
 export { DEFAULT_SOURCE_NAMES, resolveSources };
 
-export type { CcusageSource };
+export type { UsageSource };

--- a/apps/cli/src/commands/root.test.ts
+++ b/apps/cli/src/commands/root.test.ts
@@ -37,7 +37,8 @@ describe("root command", () => {
     expect(result.output).toContain("upgrade      Upgrade the globally installed CLI");
   });
 
-  it("exposes --json on all service subcommands and upgrade", () => {
+  // Seven subprocess spawns exceed the default timeout on slower machines.
+  it("exposes --json on all service subcommands and upgrade", { timeout: 60_000 }, () => {
     for (const args of [
       ["upgrade", "--help"],
       ["service", "install", "--help"],

--- a/apps/cli/src/commands/service.test.ts
+++ b/apps/cli/src/commands/service.test.ts
@@ -1338,7 +1338,9 @@ describe("serviceScheduledSyncSince", () => {
   it("uses the previous successful local date for scheduled syncs", () => {
     expect(
       serviceScheduledSyncSince(
-        { lastSuccessAt: "2026-06-16T23:30:00.000Z", version: 1 },
+        // Midday UTC keeps the local calendar date on 2026-06-16 in every
+        // timezone the tests run in, so the assertion stays TZ-independent.
+        { lastSuccessAt: "2026-06-16T12:00:00.000Z", version: 1 },
         new Date("2026-06-17T00:05:00.000Z"),
         true,
       ),

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -17,7 +17,9 @@ import {
   runCcusageSessionReport,
   sessionCcusageCommand,
 } from "../ccusage/runner";
-import { DEFAULT_SOURCE_NAMES, resolveSources } from "../ccusage/sources";
+import type { CcusageDailyReport, CcusageSessionReport } from "../ccusage/schema";
+import { DEFAULT_SOURCE_NAMES, resolveSources, type UsageSource } from "../ccusage/sources";
+import { localDailyCommand, localSessionCommand, runLocalUsageReport } from "../local";
 import {
   ApiClientService,
   BrowserService,
@@ -106,7 +108,7 @@ const syncCommand = Command.make(
       since: Option.getOrUndefined(since),
       sources: Option.getOrUndefined(sources),
     }),
-).pipe(Command.withDescription("Aggregate local agent usage via ccusage and push it"));
+).pipe(Command.withDescription("Aggregate local agent usage and push it"));
 
 interface SyncOptions {
   dryRun: boolean;
@@ -249,10 +251,10 @@ function syncProgram(options: SyncProgramOptions) {
     const renderInlineResults = shouldRenderInlineSync(options);
     for (const source of sources) {
       const spinner = yield* humanSpinner(`Syncing ${source.source}`, options);
-      const dailyReport = yield* runCcusageDailyReport(source, { since: options.since }).pipe(
+      const reports = yield* collectSourceReports(source, { since: options.since }).pipe(
         Effect.tapError(() => Effect.sync(() => spinner.error(`Failed syncing ${source.source}`))),
       );
-      if (Option.isNone(dailyReport) || dailyReport.value.daily.length === 0) {
+      if (reports.daily === null) {
         const result = { source: source.source, summary: null };
         sourceSummaries[source.source] = result.summary;
         sourceResults.push(result);
@@ -260,25 +262,19 @@ function syncProgram(options: SyncProgramOptions) {
         continue;
       }
 
-      const sourceRows = aggregateDays(source.source, dailyReport.value.daily);
+      const sourceRows = aggregateDays(source.source, reports.daily.report.daily);
       rawReports.push({
-        command: dailyCcusageCommand(source, { since: options.since }),
-        payload: dailyReport.value,
+        command: reports.daily.command,
+        payload: reports.daily.report,
         reportKind: "daily",
         source: source.source,
       });
 
-      const sessionReport = yield* runCcusageSessionReport(source, { since: options.since }).pipe(
-        Effect.tapError(() => Effect.sync(() => spinner.error(`Failed syncing ${source.source}`))),
-      );
-      const sessionCount = Option.match(sessionReport, {
-        onNone: () => null,
-        onSome: (report) => report.sessions.length,
-      });
-      if (options.since === undefined && Option.isSome(sessionReport)) {
+      const sessionCount = reports.session === null ? null : reports.session.report.sessions.length;
+      if (options.since === undefined && reports.session !== null) {
         rawReports.push({
-          command: sessionCcusageCommand(source),
-          payload: sessionReport.value,
+          command: reports.session.command,
+          payload: reports.session.report,
           reportKind: "session",
           source: source.source,
         });
@@ -337,6 +333,62 @@ function syncProgram(options: SyncProgramOptions) {
       upserted,
     };
   });
+}
+
+interface SourceReports {
+  daily: { command: string[]; report: CcusageDailyReport } | null;
+  session: { command: string[]; report: CcusageSessionReport } | null;
+}
+
+/**
+ * One collection pass per source. ccusage sources shell out per report
+ * kind; local sources (grok, antigravity) scan their data files once and
+ * derive both. A source with no daily data yields null for both — matching
+ * the historical behavior of not counting sessions for absent agents.
+ */
+function collectSourceReports(
+  source: UsageSource,
+  options: { since?: string | undefined },
+): Effect.Effect<SourceReports, unknown> {
+  if (source.collector === "ccusage") {
+    return Effect.gen(function* () {
+      const daily = yield* runCcusageDailyReport(source, { since: options.since });
+      if (Option.isNone(daily) || daily.value.daily.length === 0) {
+        return { daily: null, session: null };
+      }
+
+      const session = yield* runCcusageSessionReport(source, { since: options.since });
+      return {
+        daily: {
+          command: dailyCcusageCommand(source, { since: options.since }),
+          report: daily.value,
+        },
+        session: Option.match(session, {
+          onNone: () => null,
+          onSome: (report) => ({ command: sessionCcusageCommand(source), report }),
+        }),
+      };
+    });
+  }
+
+  return runLocalUsageReport(source, { since: options.since }).pipe(
+    Effect.map((report) => {
+      if (Option.isNone(report) || report.value.days.length === 0) {
+        return { daily: null, session: null };
+      }
+
+      return {
+        daily: {
+          command: localDailyCommand(source, { since: options.since }),
+          report: { daily: report.value.days },
+        },
+        session: {
+          command: localSessionCommand(source),
+          report: { sessions: report.value.sessionIds.map((id) => ({ id })) },
+        },
+      };
+    }),
+  );
 }
 
 function uploadUsageReports({

--- a/apps/cli/src/local/antigravity.test.ts
+++ b/apps/cli/src/local/antigravity.test.ts
@@ -1,0 +1,254 @@
+import { mkdirSync } from "node:fs";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { aggregateGenerations, collectAntigravityUsage, parseGenMetadata } from "./antigravity";
+
+const TS_1 = 1_784_660_861; // 2026-07-21T19:07:41Z
+const TS_2 = 1_784_670_000;
+
+function varint(value: number): number[] {
+  const bytes: number[] = [];
+  let remaining = BigInt(value);
+  while (remaining > 0x7fn) {
+    bytes.push(Number(remaining & 0x7fn) | 0x80);
+    remaining >>= 7n;
+  }
+  bytes.push(Number(remaining));
+
+  return bytes;
+}
+
+function varintField(field: number, value: number): number[] {
+  return [...varint((field << 3) | 0), ...varint(value)];
+}
+
+function bytesField(field: number, data: Uint8Array): number[] {
+  return [...varint((field << 3) | 2), ...varint(data.length), ...data];
+}
+
+function stringField(field: number, value: string): number[] {
+  return bytesField(field, new TextEncoder().encode(value));
+}
+
+function messageField(field: number, parts: number[][]): number[] {
+  return bytesField(field, new Uint8Array(parts.flat()));
+}
+
+/** Mirrors the reverse-engineered agy 1.1.x gen_metadata wire shape. */
+function genMetadataBlob(model: string, ts: number, usage: number[][]): Uint8Array {
+  return new Uint8Array(
+    messageField(1, [
+      messageField(4, usage),
+      messageField(9, [messageField(4, [varintField(1, ts)])]),
+      stringField(19, model),
+    ]),
+  );
+}
+
+function pricingResponse() {
+  return {
+    data: [
+      {
+        id: "anthropic/claude-sonnet-4.6",
+        pricing: { completion: "0.000015", input_cache_read: "0.0000003", prompt: "0.000003" },
+      },
+    ],
+  };
+}
+
+function okFetch() {
+  return () => Promise.resolve(new Response(JSON.stringify(pricingResponse()), { status: 200 }));
+}
+
+describe("parseGenMetadata", () => {
+  it("extracts model, timestamp, and token usage", () => {
+    const blob = genMetadataBlob("claude-sonnet-4-6", TS_1, [
+      varintField(2, 19_346),
+      varintField(3, 219),
+      varintField(5, 18_814),
+    ]);
+
+    expect(parseGenMetadata(blob)).toEqual({
+      cacheReadTokens: 18_814,
+      inputTokens: 19_346,
+      model: "claude-sonnet-4-6",
+      outputTokens: 219,
+      ts: TS_1,
+    });
+  });
+
+  it("defaults missing cached tokens to zero", () => {
+    const blob = genMetadataBlob("gemini-3.6-flash", TS_1, [
+      varintField(2, 18_184),
+      varintField(3, 500),
+    ]);
+
+    expect(parseGenMetadata(blob)?.cacheReadTokens).toBe(0);
+  });
+
+  it("rejects blobs that drifted from the known shape", () => {
+    // No usage message.
+    expect(
+      parseGenMetadata(
+        new Uint8Array(
+          messageField(1, [
+            messageField(9, [messageField(4, [varintField(1, TS_1)])]),
+            stringField(19, "claude-sonnet-4-6"),
+          ]),
+        ),
+      ),
+    ).toBeNull();
+    // No timestamp.
+    expect(
+      parseGenMetadata(
+        new Uint8Array(
+          messageField(1, [
+            messageField(4, [varintField(2, 10), varintField(3, 5)]),
+            stringField(19, "claude-sonnet-4-6"),
+          ]),
+        ),
+      ),
+    ).toBeNull();
+    // Model field is not a printable model id.
+    expect(
+      parseGenMetadata(
+        new Uint8Array(
+          messageField(1, [
+            messageField(4, [varintField(2, 10), varintField(3, 5)]),
+            messageField(9, [messageField(4, [varintField(1, TS_1)])]),
+            bytesField(19, new Uint8Array([0xff, 0x00, 0x01])),
+          ]),
+        ),
+      ),
+    ).toBeNull();
+    // Garbage.
+    expect(parseGenMetadata(new Uint8Array([1, 2, 3]))).toBeNull();
+  });
+});
+
+describe("aggregateGenerations", () => {
+  const pricing = {
+    claudesonnet46: { completion: 0.000015, inputCacheRead: 0.0000003, prompt: 0.000003 },
+  };
+
+  it("buckets by day and prices via the OpenRouter table", () => {
+    const dayOf = (ts: number) => (ts < TS_2 ? "2026-07-21" : "2026-07-22");
+    const days = aggregateGenerations(
+      [
+        {
+          cacheReadTokens: 0,
+          inputTokens: 100_000,
+          model: "claude-sonnet-4-6",
+          outputTokens: 10_000,
+          ts: TS_1,
+        },
+        {
+          cacheReadTokens: 0,
+          inputTokens: 2_000,
+          model: "unknown-future-model",
+          outputTokens: 50,
+          ts: TS_1,
+        },
+      ],
+      { dayOf, pricing },
+    );
+
+    expect(days).toHaveLength(1);
+    const [claude, unknown] = days[0]!.modelBreakdowns!;
+    expect(claude).toMatchObject({
+      cacheReadTokens: 0,
+      inputTokens: 100_000,
+      modelName: "claude-sonnet-4-6",
+      outputTokens: 10_000,
+    });
+    // 100_000*3e-6 + 10_000*15e-6, rounded to cents.
+    expect(claude?.cost).toBe(0.45);
+    // Unpriced models report tokens at cost 0.
+    expect(unknown).toMatchObject({
+      cost: 0,
+      inputTokens: 2_000,
+      modelName: "unknown-future-model",
+    });
+  });
+});
+
+describe("collectAntigravityUsage", () => {
+  let home: string;
+  let cacheDir: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "tokenmaxxing-agy-home-"));
+    cacheDir = await mkdtemp(join(tmpdir(), "tokenmaxxing-agy-cache-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { force: true, recursive: true });
+    await rm(cacheDir, { force: true, recursive: true });
+  });
+
+  function writeConversationDb(name: string, blobs: Uint8Array[]): void {
+    const dir = join(home, "conversations");
+    mkdirSync(dir, { recursive: true });
+    const db = new DatabaseSync(join(dir, name));
+    db.exec("CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB)");
+    for (const [idx, blob] of blobs.entries()) {
+      db.prepare("INSERT INTO gen_metadata (idx, data) VALUES (?, ?)").run(idx, blob);
+    }
+    db.close();
+  }
+
+  it("returns empty when the conversations dir is missing", async () => {
+    expect(await collectAntigravityUsage({ cacheDir, home })).toEqual({
+      days: [],
+      sessionIds: [],
+    });
+  });
+
+  it("aggregates generations across conversation databases", async () => {
+    await mkdir(join(home, "conversations"), { recursive: true });
+    writeConversationDb("conv-a.db", [
+      genMetadataBlob("claude-sonnet-4-6", TS_1, [varintField(2, 100_000), varintField(3, 10_000)]),
+    ]);
+    writeConversationDb("conv-b.db", [
+      genMetadataBlob("claude-sonnet-4-6", TS_1, [varintField(2, 200_000), varintField(3, 20_000)]),
+      // Drifted shape — skipped, not fatal.
+      new Uint8Array([9, 9, 9]),
+    ]);
+
+    const report = await collectAntigravityUsage({
+      cacheDir,
+      dayOf: () => "2026-07-21",
+      fetchFn: okFetch(),
+      home,
+    });
+
+    expect(report.sessionIds).toEqual(["conv-a", "conv-b"]);
+    expect(report.days).toHaveLength(1);
+    expect(report.days[0]?.modelBreakdowns?.[0]).toMatchObject({
+      inputTokens: 300_000,
+      modelName: "claude-sonnet-4-6",
+      outputTokens: 30_000,
+    });
+    // 300_000*3e-6 + 30_000*15e-6, rounded to cents.
+    expect(report.days[0]?.modelBreakdowns?.[0]?.cost).toBe(1.35);
+  });
+
+  it("does not fetch pricing when there is no data", async () => {
+    await mkdir(join(home, "conversations"), { recursive: true });
+    let fetched = false;
+    const fetchFn = () => {
+      fetched = true;
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    };
+
+    const report = await collectAntigravityUsage({ cacheDir, fetchFn, home });
+
+    expect(report).toEqual({ days: [], sessionIds: [] });
+    expect(fetched).toBe(false);
+  });
+});

--- a/apps/cli/src/local/antigravity.ts
+++ b/apps/cli/src/local/antigravity.ts
@@ -1,0 +1,292 @@
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { CcusageDay } from "../ccusage/schema";
+import { roundUsd } from "./cost";
+import { localDay, onOrAfter } from "./dates";
+import type { LocalUsageReport } from "./grok";
+import type { LoadPricingOptions, PricingTable } from "./openrouter";
+import { estimateCost, loadOpenRouterPricing, matchPricing } from "./openrouter";
+import { fieldMessage, fieldNumber, fieldString, findField, readProtoFields } from "./protobuf";
+
+/**
+ * Antigravity (agy) keeps one SQLite database per conversation under
+ * ~/.gemini/antigravity-cli/conversations/<uuid>.db. The gen_metadata table
+ * holds one protobuf blob per model generation; field numbers below were
+ * reverse-engineered from agy 1.1.x and are validated shape-first, so a
+ * future schema change degrades to "no data" instead of bad numbers:
+ *
+ *   .1        generation record
+ *   .1.4      usage message: 2 = input tokens, 3 = output tokens, 5 = cached
+ *   .1.9.4.1  generation timestamp (unix seconds)
+ *   .1.19     model id (e.g. "claude-sonnet-4-6", "gemini-3.6-flash")
+ *
+ * Input tokens exclude cached tokens already (claude-style). No cost is
+ * recorded locally, so costs are estimated from OpenRouter list prices —
+ * unknown models degrade to cost 0 and report tokens only.
+ */
+
+interface AntigravityGeneration {
+  cacheReadTokens: number;
+  inputTokens: number;
+  model: string;
+  outputTokens: number;
+  ts: number;
+}
+
+interface TokenTotals {
+  cacheReadTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+interface CollectOptions extends LoadPricingOptions {
+  cacheDir?: string | undefined;
+  dayOf?: ((epochSeconds: number) => string) | undefined;
+  home?: string | undefined;
+  since?: string | undefined;
+}
+
+const MODEL_ID_PATTERN = /^[a-z0-9][a-z0-9._/ -]{2,63}$/i;
+
+/**
+ * node:sqlite under Node (the shipped CLI), bun:sqlite under Bun (dev and
+ * the compiled service runners). The specifier is built at runtime so
+ * `bun build --target node` doesn't try to resolve it statically.
+ */
+interface SqliteDatabase {
+  close(): void;
+  prepare(sql: string): { all(): unknown[] };
+}
+
+type OpenDatabase = (path: string) => SqliteDatabase;
+
+async function loadSqlite(): Promise<OpenDatabase | undefined> {
+  if (process.versions.bun !== undefined) {
+    const module = (await import("bun:sqlite").catch(() => undefined)) as
+      | { Database?: new (path: string, options?: { readonly?: boolean }) => SqliteDatabase }
+      | undefined;
+    const Database = module?.Database;
+    return Database === undefined
+      ? undefined
+      : (path) => openReadOnly(path, (p) => new Database(p, { readonly: true }));
+  }
+
+  const module = (await import("node:sqlite").catch(() => undefined)) as
+    | { DatabaseSync?: new (path: string, options?: { readOnly?: boolean }) => SqliteDatabase }
+    | undefined;
+  const DatabaseSync = module?.DatabaseSync;
+  return DatabaseSync === undefined
+    ? undefined
+    : (path) => openReadOnly(path, (p) => new DatabaseSync(p, { readOnly: true }));
+}
+
+/**
+ * Read-only, falling back to an immutable open: agy checkpoints and deletes
+ * the -wal/-shm files on close, and a WAL-mode database without them cannot
+ * be opened plain-readonly (SQLite would need to create the shm file).
+ * bun:sqlite opens lazily, so a probe query forces the file open here.
+ */
+function openReadOnly(path: string, open: (path: string) => SqliteDatabase): SqliteDatabase {
+  for (const candidate of [path, `file:${encodeURI(path)}?immutable=1`]) {
+    try {
+      const db = open(candidate);
+      db.prepare("SELECT 1").all();
+      return db;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  throw new Error(`cannot open ${path}`);
+}
+
+/** One gen_metadata blob -> one generation, or null when the shape drifts. */
+function parseGenMetadata(data: Uint8Array): AntigravityGeneration | null {
+  const record = fieldMessage(findField(readProtoFields(data), 1));
+  if (record.length === 0) {
+    return null;
+  }
+
+  const model = fieldString(findField(record, 19));
+  const usage = fieldMessage(findField(record, 4));
+  const inputTokens = fieldNumber(findField(usage, 2));
+  const outputTokens = fieldNumber(findField(usage, 3));
+  const cacheReadTokens = fieldNumber(findField(usage, 5)) ?? 0;
+  const timing = fieldMessage(findField(record, 9));
+  const timestamp = fieldNumber(findField(fieldMessage(findField(timing, 4)), 1));
+
+  if (
+    model === undefined ||
+    !MODEL_ID_PATTERN.test(model) ||
+    timestamp === undefined ||
+    timestamp < 1e9 ||
+    timestamp >= 1e12 ||
+    (inputTokens === undefined && outputTokens === undefined)
+  ) {
+    return null;
+  }
+
+  return {
+    cacheReadTokens,
+    inputTokens: inputTokens ?? 0,
+    model,
+    outputTokens: outputTokens ?? 0,
+    ts: timestamp,
+  };
+}
+
+/** Pure: bucket generations into claude-dialect days, pricing cost from OpenRouter. */
+function aggregateGenerations(
+  generations: readonly AntigravityGeneration[],
+  options: {
+    dayOf?: ((epochSeconds: number) => string) | undefined;
+    pricing?: PricingTable | undefined;
+    since?: string | undefined;
+  } = {},
+): CcusageDay[] {
+  const dayOf = options.dayOf ?? localDay;
+  const pricing = options.pricing ?? {};
+  const byDay = new Map<string, Map<string, { cost: number; tokens: TokenTotals }>>();
+
+  for (const generation of generations) {
+    const date = dayOf(generation.ts);
+    if (!onOrAfter(date, options.since)) {
+      continue;
+    }
+
+    let dayModels = byDay.get(date);
+    if (dayModels === undefined) {
+      dayModels = new Map();
+      byDay.set(date, dayModels);
+    }
+    const merged = dayModels.get(generation.model) ?? {
+      cost: 0,
+      tokens: { cacheReadTokens: 0, inputTokens: 0, outputTokens: 0 },
+    };
+    dayModels.set(generation.model, {
+      cost:
+        merged.cost +
+        estimateCost(
+          {
+            cacheReadTokens: generation.cacheReadTokens,
+            inputTokens: generation.inputTokens,
+            outputTokens: generation.outputTokens,
+          },
+          matchPricing(pricing, generation.model),
+        ),
+      tokens: {
+        cacheReadTokens: merged.tokens.cacheReadTokens + generation.cacheReadTokens,
+        inputTokens: merged.tokens.inputTokens + generation.inputTokens,
+        outputTokens: merged.tokens.outputTokens + generation.outputTokens,
+      },
+    });
+  }
+
+  return [...byDay.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, models]) => {
+      const modelBreakdowns = [...models.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([modelName, entry]) => ({
+          cacheCreationTokens: 0,
+          cacheReadTokens: entry.tokens.cacheReadTokens,
+          cost: roundUsd(entry.cost),
+          inputTokens: entry.tokens.inputTokens,
+          modelName,
+          outputTokens: entry.tokens.outputTokens,
+        }));
+
+      return {
+        date,
+        modelBreakdowns,
+        totalCost: roundUsd(modelBreakdowns.reduce((sum, entry) => sum + entry.cost, 0)),
+      };
+    });
+}
+
+/** Every conversation database under ~/.gemini/antigravity-cli, aggregated. */
+async function collectAntigravityUsage(options: CollectOptions = {}): Promise<LocalUsageReport> {
+  const openDatabase = await loadSqlite();
+  if (openDatabase === undefined) {
+    return { days: [], sessionIds: [] };
+  }
+
+  const home = options.home ?? join(homedir(), ".gemini", "antigravity-cli");
+  const conversationsDir = join(home, "conversations");
+  let entries;
+  try {
+    entries = await readdir(conversationsDir, { withFileTypes: true });
+  } catch {
+    return { days: [], sessionIds: [] };
+  }
+
+  const since = options.since;
+  const dayOf = options.dayOf ?? localDay;
+  const generations: AntigravityGeneration[] = [];
+  const sessionIds: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".db")) {
+      continue;
+    }
+
+    let sessionGenerations: AntigravityGeneration[];
+    try {
+      sessionGenerations = readGenerations(openDatabase, join(conversationsDir, entry.name));
+    } catch {
+      continue;
+    }
+
+    const inRange = sessionGenerations.filter((generation) =>
+      onOrAfter(dayOf(generation.ts), since),
+    );
+    if (inRange.length === 0) {
+      continue;
+    }
+
+    sessionIds.push(entry.name.replace(/\.db$/, ""));
+    generations.push(...inRange);
+  }
+
+  if (generations.length === 0) {
+    return { days: [], sessionIds };
+  }
+
+  // No local data must never cost a network call.
+  const pricing =
+    options.cacheDir === undefined
+      ? {}
+      : await loadOpenRouterPricing(options.cacheDir, options).catch(() => ({}));
+
+  return {
+    days: aggregateGenerations(generations, { dayOf, pricing, since }),
+    sessionIds,
+  };
+}
+
+function readGenerations(openDatabase: OpenDatabase, dbPath: string): AntigravityGeneration[] {
+  const db = openDatabase(dbPath);
+  try {
+    const rows = db.prepare("SELECT data FROM gen_metadata").all();
+    const generations: AntigravityGeneration[] = [];
+    for (const row of rows) {
+      const data = (row as { data?: unknown }).data;
+      if (!(data instanceof Uint8Array)) {
+        continue;
+      }
+      const generation = parseGenMetadata(data);
+      if (generation !== null) {
+        generations.push(generation);
+      }
+    }
+
+    return generations;
+  } finally {
+    db.close();
+  }
+}
+
+export { aggregateGenerations, collectAntigravityUsage, parseGenMetadata };
+
+export type { AntigravityGeneration };

--- a/apps/cli/src/local/cost.ts
+++ b/apps/cli/src/local/cost.ts
@@ -1,0 +1,6 @@
+/** Round to cents — API-equivalent costs are estimates; sub-cent float noise is not signal. */
+function roundUsd(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export { roundUsd };

--- a/apps/cli/src/local/dates.test.ts
+++ b/apps/cli/src/local/dates.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { localDay, onOrAfter } from "./dates";
+
+// 2026-07-22T00:30:00Z — straddles the UTC day boundary for local-time tests.
+const AFTER_MIDNIGHT_UTC = 1_784_680_200;
+
+describe("localDay", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("buckets in local time, not UTC", () => {
+    vi.stubEnv("TZ", "UTC");
+    expect(localDay(AFTER_MIDNIGHT_UTC)).toBe("2026-07-22");
+
+    vi.stubEnv("TZ", "America/New_York");
+    expect(localDay(AFTER_MIDNIGHT_UTC)).toBe("2026-07-21");
+  });
+
+  it("zero-pads month and day", () => {
+    vi.stubEnv("TZ", "UTC");
+    // 2026-01-05T12:00:00Z
+    expect(localDay(1_767_614_400)).toBe("2026-01-05");
+  });
+});
+
+describe("onOrAfter", () => {
+  it("compares YYYY-MM-DD strings inclusively", () => {
+    expect(onOrAfter("2026-07-20", undefined)).toBe(true);
+    expect(onOrAfter("2026-07-20", "2026-07-20")).toBe(true);
+    expect(onOrAfter("2026-07-21", "2026-07-20")).toBe(true);
+    expect(onOrAfter("2026-07-19", "2026-07-20")).toBe(false);
+  });
+});

--- a/apps/cli/src/local/dates.ts
+++ b/apps/cli/src/local/dates.ts
@@ -1,0 +1,22 @@
+/**
+ * Local-time day bucketing for the native collectors. ccusage buckets by
+ * local time, so dates emitted here must be local-time YYYY-MM-DD too —
+ * they are opaque strings downstream and never re-parsed into Dates.
+ */
+
+/** Epoch seconds -> local YYYY-MM-DD. */
+function localDay(epochSeconds: number): string {
+  const date = new Date(epochSeconds * 1000);
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+/** YYYY-MM-DD string compare works for the --since lower bound. */
+function onOrAfter(day: string, since: string | undefined): boolean {
+  return since === undefined || day >= since;
+}
+
+export { localDay, onOrAfter };

--- a/apps/cli/src/local/grok.test.ts
+++ b/apps/cli/src/local/grok.test.ts
@@ -1,0 +1,201 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { aggregateGrokTurns, collectGrokUsage, readGrokTurns } from "./grok";
+
+const TS_DAY_1 = 1_784_550_000; // bucketed via injected dayOf
+const TS_DAY_2 = 1_784_640_000;
+
+function dayOf(ts: number): string {
+  return ts < 1_784_600_000 ? "2026-07-19" : "2026-07-20";
+}
+
+function turnCompleted(ts: number, modelUsage: Record<string, unknown>): string {
+  return JSON.stringify({
+    params: {
+      sessionId: "sess-1",
+      update: { sessionUpdate: "turn_completed", usage: { modelUsage } },
+    },
+    timestamp: ts,
+  });
+}
+
+describe("aggregateGrokTurns", () => {
+  it("buckets per-model usage by day and converts ticks to USD", () => {
+    const days = aggregateGrokTurns(
+      [
+        {
+          modelUsage: {
+            "grok-4.5-build": {
+              cachedReadTokens: 80_000,
+              costUsdTicks: 500_000_000,
+              inputTokens: 92_065,
+              outputTokens: 633,
+            },
+          },
+          ts: TS_DAY_1,
+        },
+        {
+          modelUsage: {
+            "grok-4.5-build": {
+              cachedReadTokens: 40_000,
+              costUsdTicks: 21_456_000,
+              inputTokens: 41_423,
+              outputTokens: 346,
+            },
+            "grok-4.20": { inputTokens: 1_000, outputTokens: 50 },
+          },
+          ts: TS_DAY_1,
+        },
+        {
+          modelUsage: { "grok-4.5-build": { inputTokens: 10, outputTokens: 5 } },
+          ts: TS_DAY_2,
+        },
+      ],
+      { dayOf },
+    );
+
+    expect(days).toHaveLength(2);
+    expect(days[0]?.date).toBe("2026-07-19");
+    expect(days[0]?.totalCost).toBe(0.52);
+    expect(days[0]?.modelBreakdowns).toEqual([
+      {
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        cost: 0,
+        inputTokens: 1_000,
+        modelName: "grok-4.20",
+        outputTokens: 50,
+      },
+      {
+        cacheCreationTokens: 0,
+        cacheReadTokens: 120_000,
+        cost: 0.52,
+        inputTokens: 13_488,
+        modelName: "grok-4.5-build",
+        outputTokens: 979,
+      },
+    ]);
+    expect(days[1]?.date).toBe("2026-07-20");
+  });
+
+  it("filters days before --since", () => {
+    const days = aggregateGrokTurns(
+      [
+        { modelUsage: { grok: { inputTokens: 5, outputTokens: 5 } }, ts: TS_DAY_1 },
+        { modelUsage: { grok: { inputTokens: 5, outputTokens: 5 } }, ts: TS_DAY_2 },
+      ],
+      { dayOf, since: "2026-07-20" },
+    );
+
+    expect(days.map((day) => day.date)).toEqual(["2026-07-20"]);
+  });
+
+  it("skips turns without any token usage", () => {
+    const days = aggregateGrokTurns(
+      [
+        { modelUsage: { grok: {} }, ts: TS_DAY_1 },
+        { modelUsage: { grok: { inputTokens: 1 } }, ts: TS_DAY_1 },
+      ],
+      { dayOf },
+    );
+
+    expect(days).toHaveLength(1);
+    expect(days[0]?.modelBreakdowns?.[0]?.inputTokens).toBe(1);
+  });
+});
+
+describe("readGrokTurns", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tokenmaxxing-grok-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it("parses only valid turn_completed lines", async () => {
+    const file = join(dir, "updates.jsonl");
+    const lines = [
+      JSON.stringify({ params: { update: { sessionUpdate: "agent_message_chunk" } } }),
+      turnCompleted(TS_DAY_1, { "grok-4.5-build": { inputTokens: 100, outputTokens: 10 } }),
+      `{"params":{"update":{"sessionUpdate":"turn_completed" BROKEN`,
+      // Millisecond timestamps are rejected — seconds only.
+      turnCompleted(TS_DAY_1 * 1000, { grok: { inputTokens: 1 } }),
+      // Missing modelUsage.
+      JSON.stringify({
+        params: { update: { sessionUpdate: "turn_completed", usage: {} } },
+        timestamp: TS_DAY_1,
+      }),
+      turnCompleted(TS_DAY_2, { "grok-4.20": { inputTokens: 200, outputTokens: 20 } }),
+    ];
+    await writeFile(file, `${lines.join("\n")}\n`);
+
+    const turns = await readGrokTurns(file);
+    expect(turns).toHaveLength(2);
+    expect(turns.map((turn) => turn.ts)).toEqual([TS_DAY_1, TS_DAY_2]);
+  });
+});
+
+describe("collectGrokUsage", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "tokenmaxxing-grok-home-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { force: true, recursive: true });
+  });
+
+  it("returns empty when the sessions dir is missing", async () => {
+    expect(await collectGrokUsage({ home })).toEqual({ days: [], sessionIds: [] });
+  });
+
+  it("aggregates across sessions and counts sessions with turns", async () => {
+    const project = join(home, "sessions", "%2Ftmp%2Fproject");
+    const sessionA = join(project, "019f3706-db91-77b1-82b1-32ed3cacf1f5");
+    const sessionB = join(project, "019f84e6-1fd1-78a2-9a48-9e51f675d3b3");
+    const sessionEmpty = join(project, "empty-session");
+    await mkdir(sessionA, { recursive: true });
+    await mkdir(sessionB, { recursive: true });
+    await mkdir(sessionEmpty, { recursive: true });
+    await writeFile(join(home, "sessions", "session_search.sqlite"), "not a dir");
+    await writeFile(
+      join(sessionA, "updates.jsonl"),
+      `${turnCompleted(TS_DAY_1, { "grok-4.5-build": { inputTokens: 100, outputTokens: 10 } })}\n`,
+    );
+    await writeFile(
+      join(sessionB, "updates.jsonl"),
+      `${turnCompleted(TS_DAY_1, { "grok-4.5-build": { inputTokens: 300, outputTokens: 30 } })}\n`,
+    );
+
+    const report = await collectGrokUsage({ dayOf, home });
+
+    expect(report.sessionIds).toEqual([
+      "019f3706-db91-77b1-82b1-32ed3cacf1f5",
+      "019f84e6-1fd1-78a2-9a48-9e51f675d3b3",
+    ]);
+    expect(report.days).toHaveLength(1);
+    expect(report.days[0]?.modelBreakdowns?.[0]?.inputTokens).toBe(400);
+    expect(report.days[0]?.modelBreakdowns?.[0]?.outputTokens).toBe(40);
+  });
+
+  it("drops sessions without turns in the --since range", async () => {
+    const project = join(home, "sessions", "%2Ftmp%2Fproject");
+    const sessionA = join(project, "old-session");
+    await mkdir(sessionA, { recursive: true });
+    await writeFile(
+      join(sessionA, "updates.jsonl"),
+      `${turnCompleted(TS_DAY_1, { grok: { inputTokens: 1, outputTokens: 1 } })}\n`,
+    );
+
+    const report = await collectGrokUsage({ dayOf, home, since: "2026-07-20" });
+    expect(report).toEqual({ days: [], sessionIds: [] });
+  });
+});

--- a/apps/cli/src/local/grok.ts
+++ b/apps/cli/src/local/grok.ts
@@ -1,0 +1,257 @@
+import { createReadStream } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+import type { CcusageDay } from "../ccusage/schema";
+import { roundUsd } from "./cost";
+import { localDay, onOrAfter } from "./dates";
+
+/**
+ * Grok CLI (xAI) keeps one directory per session under
+ * ~/.grok/sessions/<url-encoded-cwd>/<session-id>/ with an updates.jsonl
+ * ACP stream. Lines whose params.update.sessionUpdate is "turn_completed"
+ * carry the turn's token usage — split per model under usage.modelUsage —
+ * plus a vendor-computed cost in costUsdTicks (nano-USD).
+ *
+ * Grok's inputTokens include cachedReadTokens; the claude dialect emitted
+ * here reports them separately, so cached tokens are subtracted from input.
+ * Streamed line-by-line with a substring pre-filter: updates.jsonl files
+ * reach tens of MB and mostly hold conversation content, which must never
+ * leave the machine.
+ */
+
+const TICKS_PER_USD = 1_000_000_000;
+
+interface GrokModelUsage {
+  cachedReadTokens?: number;
+  costUsdTicks?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+interface GrokTurnUsage {
+  modelUsage: Record<string, GrokModelUsage>;
+  ts: number;
+}
+
+interface LocalUsageReport {
+  days: CcusageDay[];
+  sessionIds: string[];
+}
+
+interface CollectOptions {
+  dayOf?: ((epochSeconds: number) => string) | undefined;
+  home?: string | undefined;
+  since?: string | undefined;
+}
+
+/** Pure: bucket per-turn usage into claude-dialect days. */
+function aggregateGrokTurns(
+  turns: readonly GrokTurnUsage[],
+  options: Pick<CollectOptions, "dayOf" | "since"> = {},
+): CcusageDay[] {
+  interface ModelTotals {
+    cacheReadTokens: number;
+    costUsdTicks: number;
+    inputTokens: number;
+    outputTokens: number;
+  }
+
+  const dayOf = options.dayOf ?? localDay;
+  const byDay = new Map<string, Map<string, ModelTotals>>();
+
+  for (const turn of turns) {
+    const date = dayOf(turn.ts);
+    if (!onOrAfter(date, options.since)) {
+      continue;
+    }
+
+    for (const [model, usage] of Object.entries(turn.modelUsage)) {
+      const input = usage.inputTokens ?? 0;
+      const cacheRead = Math.min(usage.cachedReadTokens ?? 0, input);
+      if (input === 0 && (usage.outputTokens ?? 0) === 0 && cacheRead === 0) {
+        continue;
+      }
+
+      let dayModels = byDay.get(date);
+      if (dayModels === undefined) {
+        dayModels = new Map();
+        byDay.set(date, dayModels);
+      }
+      const merged = dayModels.get(model) ?? {
+        cacheReadTokens: 0,
+        costUsdTicks: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+      };
+      dayModels.set(model, {
+        cacheReadTokens: merged.cacheReadTokens + cacheRead,
+        costUsdTicks: merged.costUsdTicks + (usage.costUsdTicks ?? 0),
+        inputTokens: merged.inputTokens + input,
+        outputTokens: merged.outputTokens + (usage.outputTokens ?? 0),
+      });
+    }
+  }
+
+  return [...byDay.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, models]) => {
+      const modelBreakdowns = [...models.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([modelName, usage]) => ({
+          cacheCreationTokens: 0,
+          cacheReadTokens: usage.cacheReadTokens,
+          cost: roundUsd(usage.costUsdTicks / TICKS_PER_USD),
+          inputTokens: usage.inputTokens - usage.cacheReadTokens,
+          modelName,
+          outputTokens: usage.outputTokens,
+        }));
+
+      return {
+        date,
+        modelBreakdowns,
+        totalCost: roundUsd(modelBreakdowns.reduce((sum, entry) => sum + entry.cost, 0)),
+      };
+    });
+}
+
+/** One session's updates.jsonl -> its turn_completed usage entries. */
+async function readGrokTurns(filePath: string): Promise<GrokTurnUsage[]> {
+  const turns: GrokTurnUsage[] = [];
+  const lines = createInterface({ input: createReadStream(filePath) });
+
+  for await (const line of lines) {
+    if (!line.includes('"turn_completed"')) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(line) as {
+        params?: { update?: { sessionUpdate?: string; usage?: { modelUsage?: unknown } } };
+        timestamp?: unknown;
+      };
+      if (parsed.params?.update?.sessionUpdate !== "turn_completed") {
+        continue;
+      }
+
+      const ts = parsed.timestamp;
+      const modelUsage = parsed.params.update.usage?.modelUsage;
+      if (
+        typeof ts !== "number" ||
+        ts <= 0 ||
+        ts >= 1e12 ||
+        modelUsage === undefined ||
+        modelUsage === null ||
+        typeof modelUsage !== "object"
+      ) {
+        continue;
+      }
+
+      turns.push({ modelUsage: modelUsage as Record<string, GrokModelUsage>, ts });
+    } catch {
+      // Partial/garbled line — skip it.
+    }
+  }
+
+  return turns;
+}
+
+/** Every session under ~/.grok (or $GROK_HOME), aggregated. */
+async function collectGrokUsage(options: CollectOptions = {}): Promise<LocalUsageReport> {
+  const home = options.home ?? process.env["GROK_HOME"] ?? join(homedir(), ".grok");
+  const sessionsRoot = join(home, "sessions");
+
+  const days: CcusageDay[] = [];
+  const sessionIds: string[] = [];
+  let projectDirs;
+  try {
+    projectDirs = await readdir(sessionsRoot, { withFileTypes: true });
+  } catch {
+    return { days, sessionIds };
+  }
+
+  for (const projectDir of projectDirs) {
+    if (!projectDir.isDirectory()) {
+      continue;
+    }
+
+    let sessionDirs;
+    try {
+      sessionDirs = await readdir(join(sessionsRoot, projectDir.name), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const sessionDir of sessionDirs) {
+      if (!sessionDir.isDirectory()) {
+        continue;
+      }
+
+      let turns: GrokTurnUsage[];
+      try {
+        turns = await readGrokTurns(
+          join(sessionsRoot, projectDir.name, sessionDir.name, "updates.jsonl"),
+        );
+      } catch {
+        continue;
+      }
+
+      // Sessions count only when they have turns in the requested range.
+      const dayOf = options.dayOf ?? localDay;
+      const inRange = turns.filter((turn) => onOrAfter(dayOf(turn.ts), options.since));
+      if (inRange.length === 0) {
+        continue;
+      }
+
+      sessionIds.push(sessionDir.name);
+      days.push(...aggregateGrokTurns(inRange, options));
+    }
+  }
+
+  return { days: mergeDays(days), sessionIds };
+}
+
+/** Sessions each produce disjoint day rows; merge them back together. */
+function mergeDays(days: readonly CcusageDay[]): CcusageDay[] {
+  const byDay = new Map<string, CcusageDay>();
+
+  for (const day of days) {
+    const existing = byDay.get(day.date);
+    if (existing === undefined) {
+      byDay.set(day.date, { ...day, modelBreakdowns: [...(day.modelBreakdowns ?? [])] });
+      continue;
+    }
+
+    const breakdowns = [...(existing.modelBreakdowns ?? [])];
+    for (const breakdown of day.modelBreakdowns ?? []) {
+      const index = breakdowns.findIndex((entry) => entry.modelName === breakdown.modelName);
+      if (index === -1) {
+        breakdowns.push({ ...breakdown });
+      } else {
+        const match = breakdowns[index]!;
+        breakdowns[index] = {
+          ...match,
+          cacheCreationTokens:
+            (match.cacheCreationTokens ?? 0) + (breakdown.cacheCreationTokens ?? 0),
+          cacheReadTokens: (match.cacheReadTokens ?? 0) + (breakdown.cacheReadTokens ?? 0),
+          cost: roundUsd((match.cost ?? 0) + (breakdown.cost ?? 0)),
+          inputTokens: (match.inputTokens ?? 0) + (breakdown.inputTokens ?? 0),
+          outputTokens: (match.outputTokens ?? 0) + (breakdown.outputTokens ?? 0),
+        };
+      }
+    }
+    byDay.set(day.date, {
+      ...existing,
+      modelBreakdowns: breakdowns,
+      totalCost: roundUsd((existing.totalCost ?? 0) + (day.totalCost ?? 0)),
+    });
+  }
+
+  return [...byDay.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export { aggregateGrokTurns, collectGrokUsage, readGrokTurns };
+
+export type { GrokModelUsage, GrokTurnUsage, LocalUsageReport };

--- a/apps/cli/src/local/index.ts
+++ b/apps/cli/src/local/index.ts
@@ -1,0 +1,69 @@
+import { dirname } from "node:path";
+
+import { Data, Effect, Option } from "effect";
+
+import type { UsageSource } from "../ccusage/sources";
+import { getConfigPath } from "../services/config";
+import { collectAntigravityUsage } from "./antigravity";
+import type { LocalUsageReport } from "./grok";
+import { collectGrokUsage } from "./grok";
+
+/**
+ * Effect-facing glue for the native collectors (grok, antigravity). Both
+ * read local data files directly — no subprocess — and emit claude-dialect
+ * day rows so the sync pipeline and the server-side parser treat them
+ * exactly like ccusage output. Fail-soft like the ccusage runner: one
+ * broken source must never abort the whole sync.
+ */
+
+class LocalCollectError extends Data.TaggedError("LocalCollectError")<{
+  readonly cause: unknown;
+  readonly source: string;
+}> {}
+
+type LocalUsageSource = Extract<UsageSource, { collector: "antigravity" | "grok" }>;
+
+interface RunOptions {
+  /** YYYY-MM-DD lower bound on the local-time day buckets. */
+  since?: string | undefined;
+}
+
+function runLocalUsageReport(
+  source: LocalUsageSource,
+  options: RunOptions = {},
+): Effect.Effect<Option.Option<LocalUsageReport>, LocalCollectError> {
+  const collect =
+    source.collector === "grok"
+      ? collectGrokUsage({ since: options.since })
+      : collectAntigravityUsage({
+          cacheDir: dirname(getConfigPath()),
+          since: options.since,
+        });
+
+  return Effect.tryPromise({
+    catch: (cause) => new LocalCollectError({ cause, source: source.source }),
+    try: () => collect,
+  }).pipe(
+    Effect.map(Option.some),
+    // Missing tool, no data dir, unreadable files: skip the source.
+    Effect.catchCause(() => Effect.succeedNone),
+  );
+}
+
+/** Informational stand-in for the ccusage command, stored with the report. */
+function localDailyCommand(source: LocalUsageSource, options: RunOptions = {}): string[] {
+  const args = ["tokenmaxxing-local", source.source, "daily"];
+  if (options.since !== undefined) {
+    args.push("--since", options.since.replaceAll("-", ""));
+  }
+
+  return args;
+}
+
+function localSessionCommand(source: LocalUsageSource): string[] {
+  return ["tokenmaxxing-local", source.source, "session"];
+}
+
+export { localDailyCommand, localSessionCommand, runLocalUsageReport };
+
+export type { LocalUsageSource };

--- a/apps/cli/src/local/openrouter.test.ts
+++ b/apps/cli/src/local/openrouter.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { estimateCost, loadOpenRouterPricing, matchPricing, normalizeModelKey } from "./openrouter";
+
+const MODELS_PAYLOAD = {
+  data: [
+    {
+      id: "anthropic/claude-sonnet-4.6",
+      pricing: { completion: "0.000015", input_cache_read: "0.0000003", prompt: "0.000003" },
+    },
+    {
+      id: "google/gemini-3.6-flash",
+      pricing: { completion: "0.0000075", input_cache_read: "0.00000015", prompt: "0.0000015" },
+    },
+    // No pricing object — skipped.
+    { id: "broken/entry" },
+  ],
+};
+
+function okFetch(payload: unknown = MODELS_PAYLOAD) {
+  return () => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
+}
+
+describe("normalizeModelKey", () => {
+  it("matches agy model ids to openrouter ids", () => {
+    expect(normalizeModelKey("anthropic/claude-sonnet-4.6")).toBe("claudesonnet46");
+    expect(normalizeModelKey("claude-sonnet-4-6")).toBe("claudesonnet46");
+    expect(normalizeModelKey("gemini-3.6-flash")).toBe("gemini36flash");
+    expect(normalizeModelKey("google/gemini-3.6-flash")).toBe("gemini36flash");
+  });
+});
+
+describe("matchPricing + estimateCost", () => {
+  const table = {
+    claudesonnet46: { completion: 0.000015, inputCacheRead: 0.0000003, prompt: 0.000003 },
+  };
+
+  it("prices input, output, and cached tokens", () => {
+    const pricing = matchPricing(table, "claude-sonnet-4-6");
+    expect(pricing).toBeDefined();
+    expect(
+      estimateCost({ cacheReadTokens: 500, inputTokens: 1_000, outputTokens: 100 }, pricing),
+    ).toBeCloseTo(0.00465, 8);
+  });
+
+  it("estimates 0 for unknown models", () => {
+    expect(
+      estimateCost(
+        { cacheReadTokens: 500, inputTokens: 1_000, outputTokens: 100 },
+        matchPricing(table, "some-other-model"),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("loadOpenRouterPricing", () => {
+  let cacheDir: string;
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), "tokenmaxxing-openrouter-"));
+  });
+
+  afterEach(async () => {
+    await rm(cacheDir, { force: true, recursive: true });
+  });
+
+  it("fetches, parses, and caches the pricing table", async () => {
+    const table = await loadOpenRouterPricing(cacheDir, { fetchFn: okFetch(), now: 1_000 });
+
+    expect(matchPricing(table, "claude-sonnet-4-6")?.prompt).toBe(0.000003);
+    expect(matchPricing(table, "gemini-3.6-flash")?.completion).toBe(0.0000075);
+
+    const cached = JSON.parse(await readFile(join(cacheDir, "openrouter-pricing.json"), "utf8"));
+    expect(cached.fetchedAt).toBe(1_000);
+    expect(cached.prices["claudesonnet46"]).toBeDefined();
+  });
+
+  it("serves a fresh cache without fetching", async () => {
+    await writeFile(
+      join(cacheDir, "openrouter-pricing.json"),
+      JSON.stringify({
+        fetchedAt: 1_000,
+        prices: { claudesonnet46: { completion: 1, inputCacheRead: 1, prompt: 1 } },
+      }),
+    );
+    let fetched = false;
+    const fetchFn = () => {
+      fetched = true;
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    };
+
+    const table = await loadOpenRouterPricing(cacheDir, { fetchFn, now: 1_001 });
+
+    expect(fetched).toBe(false);
+    expect(table["claudesonnet46"]?.prompt).toBe(1);
+  });
+
+  it("falls back to a stale cache when the fetch fails", async () => {
+    await writeFile(
+      join(cacheDir, "openrouter-pricing.json"),
+      JSON.stringify({
+        fetchedAt: 1_000,
+        prices: { claudesonnet46: { completion: 2, inputCacheRead: 2, prompt: 2 } },
+      }),
+    );
+    const fetchFn = () => Promise.reject(new Error("offline"));
+
+    const table = await loadOpenRouterPricing(cacheDir, {
+      fetchFn,
+      now: 1_000 + 48 * 60 * 60 * 1000,
+    });
+
+    expect(table["claudesonnet46"]?.prompt).toBe(2);
+  });
+
+  it("degrades to an empty table when fetch and cache both fail", async () => {
+    const fetchFn = () => Promise.reject(new Error("offline"));
+    expect(await loadOpenRouterPricing(cacheDir, { fetchFn })).toEqual({});
+  });
+
+  it("degrades on malformed payloads", async () => {
+    const table = await loadOpenRouterPricing(cacheDir, {
+      fetchFn: okFetch({ unexpected: true }),
+    });
+    expect(table).toEqual({});
+  });
+});

--- a/apps/cli/src/local/openrouter.ts
+++ b/apps/cli/src/local/openrouter.ts
@@ -1,0 +1,161 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/**
+ * API-equivalent cost estimation for sources that record tokens but no
+ * cost (antigravity). OpenRouter's public model list carries per-token USD
+ * list prices; the table is cached on disk for 24h so the 5-minute service
+ * sync doesn't hammer the API. Any failure (offline, API down, unknown
+ * model) degrades to cost 0 — tokens still sync.
+ */
+
+const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+const CACHE_FILE = "openrouter-pricing.json";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10_000;
+
+interface OpenRouterPricing {
+  /** USD per output token. */
+  completion: number;
+  /** USD per cached-read input token. */
+  inputCacheRead: number;
+  /** USD per input token. */
+  prompt: number;
+}
+
+/** Normalized model id (no provider prefix) -> pricing. */
+type PricingTable = Record<string, OpenRouterPricing>;
+
+interface LoadPricingOptions {
+  fetchFn?: FetchLike | undefined;
+  now?: number | undefined;
+}
+
+/** Narrow fetch signature — the DOM typeof fetch carries unrelated statics. */
+type FetchLike = (
+  input: string | URL,
+  init?: { signal?: AbortSignal | undefined },
+) => Promise<Response>;
+
+/** "anthropic/claude-sonnet-4.6" and "claude-sonnet-4-6" both -> "claudesonnet46". */
+function normalizeModelKey(id: string): string {
+  const suffix = id.includes("/") ? (id.split("/").pop() ?? id) : id;
+  return suffix.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+}
+
+function matchPricing(table: PricingTable, model: string): OpenRouterPricing | undefined {
+  return table[normalizeModelKey(model)];
+}
+
+function estimateCost(
+  usage: { cacheReadTokens: number; inputTokens: number; outputTokens: number },
+  pricing: OpenRouterPricing | undefined,
+): number {
+  if (pricing === undefined) {
+    return 0;
+  }
+
+  return (
+    usage.inputTokens * pricing.prompt +
+    usage.outputTokens * pricing.completion +
+    usage.cacheReadTokens * pricing.inputCacheRead
+  );
+}
+
+interface PricingCacheFile {
+  fetchedAt: number;
+  prices: PricingTable;
+}
+
+/** Fresh cache, else refetch; stale cache beats nothing when fetch fails. */
+async function loadOpenRouterPricing(
+  cacheDir: string,
+  options: LoadPricingOptions = {},
+): Promise<PricingTable> {
+  const now = options.now ?? Date.now();
+  const cached = await readPricingCache(join(cacheDir, CACHE_FILE));
+  if (cached !== null && now - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.prices;
+  }
+
+  try {
+    const fetchFn = options.fetchFn ?? fetch;
+    const response = await fetchFn(OPENROUTER_MODELS_URL, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`openrouter responded ${response.status}`);
+    }
+
+    const prices = parseModelsResponse(await response.json());
+    await writePricingCache(join(cacheDir, CACHE_FILE), { fetchedAt: now, prices });
+    return prices;
+  } catch {
+    return cached?.prices ?? {};
+  }
+}
+
+function parseModelsResponse(payload: unknown): PricingTable {
+  const data = (payload as { data?: unknown })?.data;
+  if (!Array.isArray(data)) {
+    return {};
+  }
+
+  const prices: PricingTable = {};
+  for (const entry of data) {
+    const id = (entry as { id?: unknown })?.id;
+    const pricing = (entry as { pricing?: unknown })?.pricing;
+    if (typeof id !== "string" || pricing === null || typeof pricing !== "object") {
+      continue;
+    }
+
+    const prompt = parsePrice((pricing as Record<string, unknown>)["prompt"]);
+    const completion = parsePrice((pricing as Record<string, unknown>)["completion"]);
+    if (prompt === undefined || completion === undefined) {
+      continue;
+    }
+
+    prices[normalizeModelKey(id)] = {
+      completion,
+      inputCacheRead: parsePrice((pricing as Record<string, unknown>)["input_cache_read"]) ?? 0,
+      prompt,
+    };
+  }
+
+  return prices;
+}
+
+function parsePrice(value: unknown): number | undefined {
+  const price = typeof value === "string" ? Number(value) : value;
+  return typeof price === "number" && Number.isFinite(price) && price >= 0 ? price : undefined;
+}
+
+async function readPricingCache(path: string): Promise<PricingCacheFile | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Partial<PricingCacheFile>;
+    if (
+      typeof parsed.fetchedAt !== "number" ||
+      parsed.prices === null ||
+      typeof parsed.prices !== "object"
+    ) {
+      return null;
+    }
+
+    return { fetchedAt: parsed.fetchedAt, prices: parsed.prices as PricingTable };
+  } catch {
+    return null;
+  }
+}
+
+async function writePricingCache(path: string, cache: PricingCacheFile): Promise<void> {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, `${JSON.stringify(cache)}\n`);
+  } catch {
+    // Cache is best-effort — a read-only config dir must not break sync.
+  }
+}
+
+export { estimateCost, loadOpenRouterPricing, matchPricing, normalizeModelKey };
+
+export type { LoadPricingOptions, OpenRouterPricing, PricingTable };

--- a/apps/cli/src/local/protobuf.test.ts
+++ b/apps/cli/src/local/protobuf.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { fieldMessage, fieldNumber, fieldString, findField, readProtoFields } from "./protobuf";
+
+function varint(value: number): number[] {
+  const bytes: number[] = [];
+  let remaining = BigInt(value);
+  while (remaining > 0x7fn) {
+    bytes.push(Number(remaining & 0x7fn) | 0x80);
+    remaining >>= 7n;
+  }
+  bytes.push(Number(remaining));
+
+  return bytes;
+}
+
+function varintField(field: number, value: number): number[] {
+  return [...varint((field << 3) | 0), ...varint(value)];
+}
+
+function bytesField(field: number, data: Uint8Array): number[] {
+  return [...varint((field << 3) | 2), ...varint(data.length), ...data];
+}
+
+function stringField(field: number, value: string): number[] {
+  return bytesField(field, new TextEncoder().encode(value));
+}
+
+describe("readProtoFields", () => {
+  it("reads varint and length-delimited fields", () => {
+    const buf = new Uint8Array([...varintField(1, 300), ...stringField(2, "hello")]);
+    const fields = readProtoFields(buf);
+
+    expect(fieldNumber(findField(fields, 1))).toBe(300);
+    expect(fieldString(findField(fields, 2))).toBe("hello");
+  });
+
+  it("walks nested submessages", () => {
+    const inner = bytesField(2, new Uint8Array(varintField(1, 42)));
+    const buf = new Uint8Array(bytesField(1, new Uint8Array(inner)));
+
+    const nested = fieldMessage(findField(readProtoFields(buf), 1));
+    expect(fieldNumber(findField(fieldMessage(findField(nested, 2)), 1))).toBe(42);
+  });
+
+  it("decodes multi-byte varints", () => {
+    const buf = new Uint8Array(varintField(9, 1_784_660_861));
+    expect(fieldNumber(findField(readProtoFields(buf), 9))).toBe(1_784_660_861);
+  });
+
+  it("stops at truncated input instead of throwing", () => {
+    const buf = new Uint8Array([...varintField(1, 1), ...varint((2 << 3) | 2), 100, 65]);
+    const fields = readProtoFields(buf);
+
+    expect(fields).toHaveLength(1);
+    expect(fieldNumber(findField(fields, 1))).toBe(1);
+  });
+
+  it("rejects non-printable strings", () => {
+    const buf = new Uint8Array(bytesField(3, new Uint8Array([0xff, 0xfe, 0x00])));
+    expect(fieldString(findField(readProtoFields(buf), 3))).toBeUndefined();
+  });
+
+  it("returns undefined for missing fields", () => {
+    const fields = readProtoFields(new Uint8Array(varintField(1, 7)));
+    expect(findField(fields, 2)).toBeUndefined();
+    expect(fieldNumber(undefined)).toBeUndefined();
+    expect(fieldString(undefined)).toBeUndefined();
+    expect(fieldMessage(undefined)).toEqual([]);
+  });
+});

--- a/apps/cli/src/local/protobuf.ts
+++ b/apps/cli/src/local/protobuf.ts
@@ -1,0 +1,115 @@
+/**
+ * Minimal protobuf wire reader — just enough to walk length-delimited
+ * submessages and varints (antigravity's gen_metadata blobs). Fixed32/64
+ * fields are skipped; groups and other legacy wire types stop the parse
+ * instead of desynchronizing the buffer.
+ */
+
+interface ProtoField {
+  /** Present for wire type 2 (length-delimited). */
+  bytes?: Uint8Array;
+  /** Field number from the tag. */
+  field: number;
+  /** Present for wire type 0 (varint). */
+  varint?: bigint;
+  /** Wire type (0 = varint, 2 = length-delimited). */
+  wire: number;
+}
+
+function readProtoFields(buf: Uint8Array): ProtoField[] {
+  const fields: ProtoField[] = [];
+  let pos = 0;
+
+  while (pos < buf.length) {
+    const tag = readVarint(buf, pos);
+    if (tag === undefined) {
+      break;
+    }
+    pos = tag.next;
+
+    const field = Number(tag.value >> 3n);
+    const wire = Number(tag.value & 7n);
+    if (field === 0) {
+      break;
+    }
+
+    if (wire === 0) {
+      const value = readVarint(buf, pos);
+      if (value === undefined) {
+        break;
+      }
+      pos = value.next;
+      fields.push({ field, varint: value.value, wire });
+    } else if (wire === 2) {
+      const length = readVarint(buf, pos);
+      if (length === undefined) {
+        break;
+      }
+      pos = length.next;
+      const end = pos + Number(length.value);
+      if (end > buf.length) {
+        break;
+      }
+      fields.push({ bytes: buf.subarray(pos, end), field, wire });
+      pos = end;
+    } else if (wire === 5) {
+      pos += 4;
+    } else if (wire === 1) {
+      pos += 8;
+    } else {
+      break;
+    }
+  }
+
+  return fields;
+}
+
+function readVarint(buf: Uint8Array, pos: number): { next: number; value: bigint } | undefined {
+  let value = 0n;
+  let shift = 0n;
+  while (pos < buf.length && shift < 70n) {
+    const byte = buf[pos]!;
+    pos += 1;
+    value |= BigInt(byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) {
+      return { next: pos, value };
+    }
+    shift += 7n;
+  }
+
+  return undefined;
+}
+
+/** First field with the given number, if present. */
+function findField(fields: readonly ProtoField[], field: number): ProtoField | undefined {
+  return fields.find((entry) => entry.field === field);
+}
+
+/** Length-delimited field decoded as UTF-8, if printable. */
+function fieldString(field: ProtoField | undefined): string | undefined {
+  if (field?.bytes === undefined) {
+    return undefined;
+  }
+
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(field.bytes);
+  return /^[\x20-\x7e]*$/.test(text) ? text : undefined;
+}
+
+/** Submessage fields of a length-delimited field. */
+function fieldMessage(field: ProtoField | undefined): ProtoField[] {
+  return field?.bytes === undefined ? [] : readProtoFields(field.bytes);
+}
+
+/** Varint field as a number, if it fits safely. */
+function fieldNumber(field: ProtoField | undefined): number | undefined {
+  if (field?.varint === undefined) {
+    return undefined;
+  }
+
+  const value = field.varint;
+  return value <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(value) : undefined;
+}
+
+export { fieldMessage, fieldNumber, fieldString, findField, readProtoFields };
+
+export type { ProtoField };

--- a/apps/www/src/components/charts/scale.test.ts
+++ b/apps/www/src/components/charts/scale.test.ts
@@ -15,6 +15,17 @@ describe("modelSeriesLabel", () => {
     ["gpt-5.5", "GPT-5.5"],
     ["gpt-5.4", "GPT-5.4"],
     ["gpt-5", "GPT-5"],
+    ["grok-4.5", "Grok"],
+    ["grok-4.5-build", "Grok"],
+    ["kimi-for-coding", "Kimi"],
+    ["deepseek-v4-pro", "DeepSeek"],
+    ["glm-5.2", "GLM"],
+    ["gemma4", "Gemma"],
+    ["anthropic/claude-fable-5", "Claude Fable 5"],
+    ["openai/gpt-5.5-pro", "GPT-5.5"],
+    ["moonshotai/kimi-k3", "Kimi"],
+    ["deepseek/deepseek-v4-flash", "DeepSeek"],
+    ["z-ai/glm-5.2", "GLM"],
     ["unknown", "Other"],
   ])("labels %s as %s", (model, expected) => {
     expect(modelSeriesLabel(model)).toBe(expected);

--- a/apps/www/src/components/charts/scale.ts
+++ b/apps/www/src/components/charts/scale.ts
@@ -70,6 +70,11 @@ const MODEL_SERIES_RULES: readonly [RegExp, string][] = [
   [/^gpt-5/i, "GPT-5"],
   [/^gpt/i, "GPT"],
   [/codex/i, "GPT Codex"],
+  [/^grok/i, "Grok"],
+  [/kimi/i, "Kimi"],
+  [/deepseek/i, "DeepSeek"],
+  [/glm/i, "GLM"],
+  [/gemma/i, "Gemma"],
   [/gemini/i, "Gemini"],
   [/^o[0-9]/i, "OpenAI o-series"],
 ];
@@ -86,17 +91,26 @@ const MODEL_SERIES_ORDER = [
   "OpenAI o-series",
   ...CLAUDE_SERIES_ORDER,
   "Gemini",
+  "Grok",
+  "Kimi",
+  "DeepSeek",
+  "GLM",
+  "Gemma",
   "Other",
 ] as const;
 
 function modelSeriesLabel(model: string): string {
-  const claude = claudeSeriesLabel(model);
+  // OpenRouter-style ids arrive as "vendor/model"; the vendor prefix carries
+  // no series information, so match on the bare model name.
+  const name = model.slice(model.lastIndexOf("/") + 1);
+
+  const claude = claudeSeriesLabel(name);
   if (claude !== null) {
     return claude;
   }
 
   for (const [pattern, series] of MODEL_SERIES_RULES) {
-    if (pattern.test(model)) {
+    if (pattern.test(name)) {
       return series;
     }
   }
@@ -133,7 +147,10 @@ const MODEL_SERIES_COLORS = {
   "Claude Mythos": "#a855f7",
   "Claude Opus": "#eab308",
   "Claude Sonnet": "#14b8a6",
+  DeepSeek: "#4d6bfe",
   Gemini: "#ef4444",
+  Gemma: "#f59e0b",
+  GLM: "#10b981",
   GPT: "#6366f1",
   "GPT Codex": "#0ea5e9",
   "GPT-5": "#8b5cf6",
@@ -142,6 +159,8 @@ const MODEL_SERIES_COLORS = {
   "GPT-5.6 Luna": "#06b6d4",
   "GPT-5.6 Sol": "#e11d48",
   "GPT-5.6 Terra": "#ca8a04",
+  Grok: "#f43f5e",
+  Kimi: "#3b82f6",
   "OpenAI o-series": "#84cc16",
   Other: "#9ca3af",
 } as const satisfies Record<string, string>;

--- a/apps/www/src/routes/index.tsx
+++ b/apps/www/src/routes/index.tsx
@@ -137,11 +137,12 @@ const FAQ_ITEMS: { answer: ReactNode; answerText: string; question: string }[] =
         >
           ccusage
         </a>{" "}
-        to parse local usage from Claude Code, Codex, OpenCode, Gemini CLI, and Copilot CLI.
+        to parse local usage from Claude Code, Codex, OpenCode, Gemini CLI, Copilot CLI, and Kimi,
+        and ships native collectors for Grok CLI and Antigravity.
       </>
     ),
     answerText:
-      "tokenmaxxing uses ccusage to parse local usage from Claude Code, Codex, OpenCode, Gemini CLI, and Copilot CLI.",
+      "tokenmaxxing uses ccusage to parse local usage from Claude Code, Codex, OpenCode, Gemini CLI, Copilot CLI, and Kimi, and ships native collectors for Grok CLI and Antigravity.",
   },
   {
     question: "What data gets uploaded?",

--- a/apps/www/src/routes/llms[.]txt.tsx
+++ b/apps/www/src/routes/llms[.]txt.tsx
@@ -22,13 +22,16 @@ tokenmaxxing bootstrap
 
 ## Supported agents
 
-Usage is parsed locally via [ccusage](https://ccusage.com/). Only daily aggregates (date, model name, agent source, token counts, and API-equivalent cost) are uploaded — prompts, file paths, project names, and session content are never uploaded.
+Usage is parsed locally via [ccusage](https://ccusage.com/) and native collectors. Only daily aggregates (date, model name, agent source, token counts, and API-equivalent cost) are uploaded — prompts, file paths, project names, and session content are never uploaded.
 
 - Claude Code
 - OpenAI Codex
-- Cursor
 - OpenCode
 - Gemini CLI
+- GitHub Copilot CLI
+- Kimi
+- Grok CLI
+- Antigravity
 
 ## Links
 

--- a/apps/www/src/routes/privacy.tsx
+++ b/apps/www/src/routes/privacy.tsx
@@ -49,10 +49,11 @@ function PrivacyPage() {
 
         <Section title="How data is sourced">
           The CLI uses <ExternalLink href={CCUSAGE_URL}>ccusage</ExternalLink> to parse usage
-          locally from supported coding agents (Claude Code, Codex, OpenCode, Gemini CLI, and
-          Copilot CLI). It only reads usage data that still exists on your computer; if an agent has
-          already cleaned up its local logs, that data cannot be recovered or uploaded. You can
-          preview exactly what would be sent with <Code>tokenmaxxing sync --dry-run</Code>.
+          locally from supported coding agents (Claude Code, Codex, OpenCode, Gemini CLI, Copilot
+          CLI, and Kimi) and reads Grok CLI and Antigravity usage from their local data files. It
+          only reads usage data that still exists on your computer; if an agent has already cleaned
+          up its local logs, that data cannot be recovered or uploaded. You can preview exactly what
+          would be sent with <Code>tokenmaxxing sync --dry-run</Code>.
         </Section>
 
         <Section title="What is public and what is private">


### PR DESCRIPTION
## Summary

Adds two new usage sources — **Grok** and **Antigravity** — and introduces a local-file collection path alongside the existing ccusage-backed collectors. Also registers **kimi** as a ccusage source.

## Changes

### CLI

- **New `local` collector package** (`apps/cli/src/local/`):
  - `grok.ts` — reads Grok usage from its local data files
  - `antigravity.ts` — reads Antigravity usage from its local data files (protobuf decoding via `protobuf.ts`)
  - `openrouter.ts` — API-equivalent cost estimation via OpenRouter's public pricing table (details below)
  - `dates.ts`, `cost.ts`, `index.ts` — shared helpers and orchestration
- **Source registry** (`ccusage/sources.ts`): sources are now typed by collector (`ccusage` | `grok` | `antigravity`); grok and antigravity read local data directly since ccusage has no support for them. If ccusage adds them later, they can flip to ccusage collectors.
- **`--sources` alias**: `agy` resolves to `antigravity`
- **kimi** added as a ccusage subcommand source
- **`sync` command** updated to run local collectors alongside ccusage runs
- Full test coverage for all new collectors (`grok`, `antigravity`, `openrouter`, `protobuf`, `dates`, `sources`)

### Web

- `index`, `llms.txt`, and `privacy` routes updated for the new sources

### Docs / repo

- READMEs updated with the new sources
- Removed `.repos` submodule pins (alchemy-effect, effect-smol, opencode)

## Why OpenRouter?

Antigravity's local data records **token counts only — no cost**. Since the dashboard shows API-equivalent spend per day/model, a price source is needed. OpenRouter's public model list (`GET https://openrouter.ai/api/v1/models`, no auth required) carries per-token USD list prices for hundreds of models, making it the most complete free pricing dictionary available.

**Important:** OpenRouter is *not* a usage source here — no user traffic or credentials touch it. It is only a pricing lookup.

How it works (`apps/cli/src/local/openrouter.ts`):

- Fetches the model list and builds a `model → {prompt, completion, inputCacheRead}` per-token USD price table
- **Caches the table on disk for 24h** (`openrouter-pricing.json`) so the 5-minute background sync doesn't hammer the API
- **Normalizes model IDs** before matching — Antigravity's `claude-sonnet-4-6` and OpenRouter's `anthropic/claude-sonnet-4.6` both normalize to `claudesonnet46`
- Cost = `input × prompt price + output × completion price + cache-read × cache price`, rounded to cents (these are estimates; sub-cent float noise is not signal)
- **Graceful degradation:** offline, API down, 10s timeout, or unknown model → cost falls back to `0` (or a stale cache) and tokens still sync. Cost is best-effort metadata, never a reason to fail a sync

## Testing

- `bun test` (or the repo's standard test command) — new unit tests for all collectors pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/tokenmaxxing/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787259750&installation_model_id=428386&pr_number=42&repository=851-labs%2Ftokenmaxxing&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Ftokenmaxxing%2Fpull%2F42&signature=6818d69c22a7a63d0eb7b9c180bdd3e0a34518c4bb23689e2b720f8970086cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->