### PR TITLE
Show raw model names in usage charts

### DIFF
--- a/apps/www/src/components/charts/scale.test.ts
+++ b/apps/www/src/components/charts/scale.test.ts
@@ -1,22 +1,43 @@
 import { describe, expect, it } from "vitest";
 
-import { modelSeriesLabel } from "./scale";
+import { selectModelSeries } from "./scale";
 
-describe("modelSeriesLabel", () => {
-  it.each([
-    ["claude-opus-4-8", "Claude Opus 4.8"],
-    ["claude-haiku-4-5-20251001", "Claude Haiku 4.5"],
-    ["claude-fable-5", "Claude Fable 5"],
-    ["claude-opus", "Claude Opus"],
-    ["gpt-5.6", "GPT-5.6 Sol"],
-    ["gpt-5.6-sol", "GPT-5.6 Sol"],
-    ["gpt-5.6-terra", "GPT-5.6 Terra"],
-    ["gpt-5.6-luna", "GPT-5.6 Luna"],
-    ["gpt-5.5", "GPT-5.5"],
-    ["gpt-5.4", "GPT-5.4"],
-    ["gpt-5", "GPT-5"],
-    ["unknown", "Other"],
-  ])("labels %s as %s", (model, expected) => {
-    expect(modelSeriesLabel(model)).toBe(expected);
+describe("selectModelSeries", () => {
+  it("keeps raw model names when they fit within the limit", () => {
+    const rows = [
+      { key: "glm-5-turbo", value: 20 },
+      { key: "deepseek-v4", value: 10 },
+    ];
+
+    const selection = selectModelSeries(rows, (row) => row.value);
+
+    expect(selection.order).toEqual(["glm-5-turbo", "deepseek-v4"]);
+    expect(selection.label("glm-5-turbo")).toBe("glm-5-turbo");
+    expect(selection.label("deepseek-v4")).toBe("deepseek-v4");
+  });
+
+  it("reserves the final slot for the long tail", () => {
+    const rows = Array.from({ length: 11 }, (_, index) => ({
+      key: `model-${String(index + 1).padStart(2, "0")}`,
+      value: 11 - index,
+    }));
+
+    const selection = selectModelSeries(rows, (row) => row.value);
+
+    expect(selection.order).toEqual([
+      "model-01",
+      "model-02",
+      "model-03",
+      "model-04",
+      "model-05",
+      "model-06",
+      "model-07",
+      "model-08",
+      "model-09",
+      "Other",
+    ]);
+    expect(selection.label("model-09")).toBe("model-09");
+    expect(selection.label("model-10")).toBe("Other");
+    expect(selection.label("model-11")).toBe("Other");
   });
 });

--- a/apps/www/src/components/charts/scale.ts
+++ b/apps/www/src/components/charts/scale.ts
@@ -1,9 +1,5 @@
-import type { ProfileDailyRow } from "@tokenmaxxing/api-contract";
-
-type DailyRow = typeof ProfileDailyRow.Type;
-
 /**
- * Shared chart math: linear scales, model-series bucketing, and number
+ * Shared chart math, model-series selection, and number
  * formatting. Charts are pure SVG; everything here is deterministic and
  * unit-testable.
  */
@@ -45,106 +41,9 @@ function niceMax(value: number): number {
   return niceFraction * 10 ** exponent;
 }
 
-const CLAUDE_MODEL_LINES = {
-  fable: "Claude Fable",
-  haiku: "Claude Haiku",
-  mythos: "Claude Mythos",
-  opus: "Claude Opus",
-  sonnet: "Claude Sonnet",
-} as const;
-
-const CLAUDE_SERIES_ORDER = [
-  "Claude Fable",
-  "Claude Mythos",
-  "Claude Opus",
-  "Claude Sonnet",
-  "Claude Haiku",
-] as const;
-
-const MODEL_SERIES_RULES: readonly [RegExp, string][] = [
-  [/^gpt-5\.6(?:$|-sol(?:$|-))/i, "GPT-5.6 Sol"],
-  [/^gpt-5\.6-terra(?:$|-)/i, "GPT-5.6 Terra"],
-  [/^gpt-5\.6-luna(?:$|-)/i, "GPT-5.6 Luna"],
-  [/^gpt-5\.5/i, "GPT-5.5"],
-  [/^gpt-5\.4/i, "GPT-5.4"],
-  [/^gpt-5/i, "GPT-5"],
-  [/^gpt/i, "GPT"],
-  [/codex/i, "GPT Codex"],
-  [/gemini/i, "Gemini"],
-  [/^o[0-9]/i, "OpenAI o-series"],
-];
-
-const MODEL_SERIES_ORDER = [
-  "GPT-5.6 Sol",
-  "GPT-5.6 Terra",
-  "GPT-5.6 Luna",
-  "GPT-5.5",
-  "GPT-5.4",
-  "GPT-5",
-  "GPT",
-  "GPT Codex",
-  "OpenAI o-series",
-  ...CLAUDE_SERIES_ORDER,
-  "Gemini",
-  "Other",
-] as const;
-
-function modelSeriesLabel(model: string): string {
-  const claude = claudeSeriesLabel(model);
-  if (claude !== null) {
-    return claude;
-  }
-
-  for (const [pattern, series] of MODEL_SERIES_RULES) {
-    if (pattern.test(model)) {
-      return series;
-    }
-  }
-
-  return "Other";
-}
-
-function claudeSeriesLabel(model: string): string | null {
-  const match = /^claude-([a-z]+)(?:-(\d+)(?:-(\d+))?)?/i.exec(model);
-  if (match === null) {
-    return null;
-  }
-
-  const line = match[1]?.toLowerCase();
-  const base =
-    line === undefined ? undefined : CLAUDE_MODEL_LINES[line as keyof typeof CLAUDE_MODEL_LINES];
-  if (base === undefined) {
-    return "Other";
-  }
-
-  const major = match[2];
-  if (major === undefined) {
-    return base;
-  }
-
-  const minor = match[3];
-  return minor === undefined ? `${base} ${major}` : `${base} ${major}.${minor}`;
-}
-
-/** Fixed palette tuned to read on both themes. */
-const MODEL_SERIES_COLORS = {
-  "Claude Fable": "#38bdf8",
-  "Claude Haiku": "#ec4899",
-  "Claude Mythos": "#a855f7",
-  "Claude Opus": "#eab308",
-  "Claude Sonnet": "#14b8a6",
-  Gemini: "#ef4444",
-  GPT: "#6366f1",
-  "GPT Codex": "#0ea5e9",
-  "GPT-5": "#8b5cf6",
-  "GPT-5.4": "#22c55e",
-  "GPT-5.5": "#f97316",
-  "GPT-5.6 Luna": "#06b6d4",
-  "GPT-5.6 Sol": "#e11d48",
-  "GPT-5.6 Terra": "#ca8a04",
-  "OpenAI o-series": "#84cc16",
-  Other: "#9ca3af",
-} as const satisfies Record<string, string>;
+const MODEL_SERIES_LIMIT = 10;
+const OTHER_MODEL_SERIES = "Other";
+const OTHER_MODEL_SERIES_COLOR = "#9ca3af";
 
 const DYNAMIC_SERIES_COLORS = [
   "#f59e0b",
@@ -161,73 +60,59 @@ const DYNAMIC_SERIES_COLORS = [
   "#475569",
 ] as const;
 
-/** Stable series -> color assignment in canonical model-series order. */
-function seriesColors(rows: readonly DailyRow[]): Map<string, string> {
-  const seen = new Set<string>();
+interface ModelSeriesSelection {
+  label(model: string): string;
+  order: readonly string[];
+}
+
+/**
+ * Keep the highest-value raw model names and collapse only the remaining long
+ * tail. Ranking across the full chart range keeps stack positions stable from
+ * day to day.
+ */
+function selectModelSeries<Row extends { key: string }>(
+  rows: readonly Row[],
+  value: (row: Row) => number,
+  limit = MODEL_SERIES_LIMIT,
+): ModelSeriesSelection {
+  const valueByModel = new Map<string, number>();
   for (const row of rows) {
-    seen.add(modelSeriesLabel(row.key));
+    valueByModel.set(row.key, (valueByModel.get(row.key) ?? 0) + value(row));
   }
 
+  const ranked = [...valueByModel.entries()]
+    .sort(
+      ([leftModel, leftValue], [rightModel, rightValue]) =>
+        rightValue - leftValue || leftModel.localeCompare(rightModel),
+    )
+    .map(([model]) => model);
+  const safeLimit = Math.max(Math.floor(limit), 1);
+  const hasOverflow = ranked.length > safeLimit;
+  const visible = ranked.slice(0, hasOverflow ? safeLimit - 1 : safeLimit);
+  const visibleSet = new Set(visible);
+  const order = hasOverflow
+    ? [...visible.filter((model) => model !== OTHER_MODEL_SERIES), OTHER_MODEL_SERIES]
+    : visible;
+
+  return {
+    label: (model) => (visibleSet.has(model) ? model : OTHER_MODEL_SERIES),
+    order,
+  };
+}
+
+/** Stable raw-model color assignment shared by every metric on a page. */
+function seriesColors<Row extends { key: string }>(rows: readonly Row[]): Map<string, string> {
+  const models = [...new Set(rows.map((row) => row.key))].sort((a, b) => a.localeCompare(b));
   const colors = new Map<string, string>();
-  let dynamicIndex = 0;
-  for (const series of [...seen].sort(compareModelSeriesLabels)) {
-    const staticColor = MODEL_SERIES_COLORS[series as keyof typeof MODEL_SERIES_COLORS];
-    if (staticColor !== undefined) {
-      colors.set(series, staticColor);
-    } else {
-      colors.set(
-        series,
-        DYNAMIC_SERIES_COLORS[dynamicIndex % DYNAMIC_SERIES_COLORS.length] ??
-          MODEL_SERIES_COLORS.Other,
-      );
-      dynamicIndex += 1;
-    }
+  for (const [index, model] of models.entries()) {
+    colors.set(
+      model,
+      DYNAMIC_SERIES_COLORS[index % DYNAMIC_SERIES_COLORS.length] ?? OTHER_MODEL_SERIES_COLOR,
+    );
   }
+  colors.set(OTHER_MODEL_SERIES, OTHER_MODEL_SERIES_COLOR);
 
   return colors;
-}
-
-function compareModelSeriesLabels(a: string, b: string): number {
-  const left = modelSeriesSortKey(a);
-  const right = modelSeriesSortKey(b);
-
-  return (
-    left.group - right.group ||
-    left.version - right.version ||
-    left.label.localeCompare(right.label)
-  );
-}
-
-function modelSeriesSortKey(label: string) {
-  for (const [group, base] of MODEL_SERIES_ORDER.entries()) {
-    if (label === base) {
-      return { group, label, version: Number.MAX_SAFE_INTEGER };
-    }
-    if (CLAUDE_SERIES_ORDER.includes(base as (typeof CLAUDE_SERIES_ORDER)[number])) {
-      const version = claudeLabelVersion(label, base);
-      if (version !== null) {
-        return { group, label, version: -version };
-      }
-    }
-  }
-
-  return { group: MODEL_SERIES_ORDER.length, label, version: 0 };
-}
-
-function claudeLabelVersion(label: string, base: string): number | null {
-  const version = new RegExp(`^${escapeRegExp(base)} (\\d+)(?:\\.(\\d+))?$`).exec(label);
-  if (version === null) {
-    return null;
-  }
-
-  const major = Number(version[1]);
-  const minor = version[2] === undefined ? 0 : Number(version[2]);
-
-  return major * 1_000 + minor;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 const usd0 = new Intl.NumberFormat("en-US", {
@@ -317,7 +202,7 @@ export {
   formatTokens,
   formatUsd,
   linearScale,
-  modelSeriesLabel,
   niceMax,
+  selectModelSeries,
   seriesColors,
 };

--- a/apps/www/src/components/charts/stacked-bars.tsx
+++ b/apps/www/src/components/charts/stacked-bars.tsx
@@ -5,7 +5,7 @@ import { barLayout, CHART_AXIS, CHART_WIDTH, formatDay, linearScale, niceMax } f
 import { anchorBesideBar, ChartTooltip } from "./tooltip";
 
 /**
- * Daily metric, one bar per day stacked by model series. Hover reveals the
+ * Daily metric, one bar per day stacked by model. Hover reveals the
  * per-series breakdown.
  */
 

--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -13,7 +13,7 @@ import {
   enumerateDays,
   formatTokens,
   formatUsd,
-  modelSeriesLabel,
+  selectModelSeries,
   seriesColors,
 } from "../components/charts/scale";
 import { Legend, StackedBars, type StackedDay } from "../components/charts/stacked-bars";
@@ -195,7 +195,7 @@ function ProfileDashboard({
         <div aria-hidden="true" className="order-last bg-background" />
         <StatCard
           label="Top spend model"
-          value={stats.topModel === null ? "—" : modelSeriesLabel(stats.topModel.model)}
+          value={stats.topModel === null ? "—" : stats.topModel.model}
         />
         <StatCard label="Current streak" value={formatCount(stats.currentStreakDays)} />
         <StatCard label="Longest streak" value={formatCount(stats.longestStreakDays)} />
@@ -207,7 +207,7 @@ function ProfileDashboard({
         <div className="mt-4 flex flex-col gap-6 lg:flex-row lg:items-center">
           <div className="min-w-0 flex-1">
             <StackedBars
-              ariaLabel={`Daily spend by model series across ${derived.spendDays.length} days`}
+              ariaLabel={`Daily spend by model across ${derived.spendDays.length} days`}
               days={derived.spendDays}
               highlight={hoveredSpendSeries}
               valueFormatter={formatUsd}
@@ -222,7 +222,7 @@ function ProfileDashboard({
         <div className="mt-4 flex flex-col gap-6 lg:flex-row lg:items-center">
           <div className="min-w-0 flex-1">
             <StackedBars
-              ariaLabel={`Daily tokens by model series across ${derived.tokenDays.length} days`}
+              ariaLabel={`Daily tokens by model across ${derived.tokenDays.length} days`}
               days={derived.tokenDays}
               highlight={hoveredTokensSeries}
               valueFormatter={formatTokens}
@@ -265,8 +265,10 @@ function ProfileDashboard({
 
 function deriveCharts(rows: readonly DailyRow[], range: DailyRange) {
   const colors = seriesColors(rows);
+  const spendSelection = selectModelSeries(rows, (row) => row.costUsd);
+  const tokenSelection = selectModelSeries(rows, (row) => row.totalTokens);
 
-  // Per-day totals and per-day model-series segments.
+  // Per-day totals and per-day raw-model segments.
   const spendByDate = new Map<string, number>();
   const tokenByDate = new Map<string, number>();
   const spendSeriesByDate = new Map<string, Map<string, number>>();
@@ -283,18 +285,19 @@ function deriveCharts(rows: readonly DailyRow[], range: DailyRange) {
     // getUTCDay() is Sunday-first; shift to Monday-first. UTC avoids tz drift.
     const weekday = (new Date(`${row.date}T00:00:00Z`).getUTCDay() + 6) % 7;
     spendByWeekday[weekday] = (spendByWeekday[weekday] ?? 0) + row.costUsd;
-    const series = modelSeriesLabel(row.key);
+    const spendModel = spendSelection.label(row.key);
     const spendSeries = spendSeriesByDate.get(row.date) ?? new Map<string, number>();
-    spendSeries.set(series, (spendSeries.get(series) ?? 0) + row.costUsd);
+    spendSeries.set(spendModel, (spendSeries.get(spendModel) ?? 0) + row.costUsd);
     spendSeriesByDate.set(row.date, spendSeries);
+    const tokenModel = tokenSelection.label(row.key);
     const tokenSeries = tokenSeriesByDate.get(row.date) ?? new Map<string, number>();
-    tokenSeries.set(series, (tokenSeries.get(series) ?? 0) + row.totalTokens);
+    tokenSeries.set(tokenModel, (tokenSeries.get(tokenModel) ?? 0) + row.totalTokens);
     tokenSeriesByDate.set(row.date, tokenSeries);
 
     const month = row.date.slice(0, 7);
     spendByMonth.set(month, (spendByMonth.get(month) ?? 0) + row.costUsd);
     const monthSeries = seriesByMonth.get(month) ?? new Map<string, number>();
-    monthSeries.set(series, (monthSeries.get(series) ?? 0) + row.costUsd);
+    monthSeries.set(spendModel, (monthSeries.get(spendModel) ?? 0) + row.costUsd);
     seriesByMonth.set(month, monthSeries);
   }
 
@@ -304,11 +307,10 @@ function deriveCharts(rows: readonly DailyRow[], range: DailyRange) {
     last: calendarYearEnd(range.last),
   };
 
-  const seriesOrder = [...colors.keys()];
   const segmentsByDate = new Map(
     [...spendSeriesByDate.entries()].map(([date, seriesValues]) => [
       date,
-      seriesOrder.map((series) => ({
+      spendSelection.order.map((series) => ({
         color: colors.get(series) ?? "#9ca3af",
         series,
         value: seriesValues.get(series) ?? 0,
@@ -319,14 +321,14 @@ function deriveCharts(rows: readonly DailyRow[], range: DailyRange) {
   const chartedDays = allDays;
   const spendDays = buildStackedDays(
     chartedDays,
-    seriesOrder,
+    spendSelection.order,
     colors,
     spendSeriesByDate,
     spendByDate,
   );
   const tokenDays = buildStackedDays(
     chartedDays,
-    seriesOrder,
+    tokenSelection.order,
     colors,
     tokenSeriesByDate,
     tokenByDate,
@@ -334,7 +336,7 @@ function deriveCharts(rows: readonly DailyRow[], range: DailyRange) {
 
   const months = enumerateCalendarMonths(range.first, range.last).map((month) => ({
     month,
-    segments: seriesOrder.map((series) => ({
+    segments: spendSelection.order.map((series) => ({
       color: colors.get(series) ?? "#9ca3af",
       series,
       value: seriesByMonth.get(month)?.get(series) ?? 0,

--- a/apps/www/src/routes/-$user.test.ts
+++ b/apps/www/src/routes/-$user.test.ts
@@ -75,7 +75,7 @@ describe("deriveCharts", () => {
     ]);
   });
 
-  it("keeps versioned Opus models as separate series", () => {
+  it("uses raw model names as separate series", () => {
     const range: DailyRange = {
       first: "2026-06-21",
       last: "2026-06-21",
@@ -88,17 +88,49 @@ describe("deriveCharts", () => {
     const derived = deriveCharts(rows, range);
 
     expect(derived.spendLegend.map((entry) => entry.series)).toEqual([
-      "Claude Opus 4.8",
-      "Claude Opus 4.7",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
     ]);
     expect(
       derived.spendDays[0]?.segments
         .filter((segment) => segment.value > 0)
         .map((segment) => [segment.series, segment.value]),
     ).toEqual([
-      ["Claude Opus 4.8", 20],
-      ["Claude Opus 4.7", 10],
+      ["claude-opus-4-8", 20],
+      ["claude-opus-4-7", 10],
     ]);
+  });
+
+  it("collapses only models below the chart limit into Other", () => {
+    const range: DailyRange = {
+      first: "2026-06-21",
+      last: "2026-06-21",
+    };
+    const rows = Array.from({ length: 11 }, (_, index) =>
+      dailyRow({
+        costUsd: 11 - index,
+        key: `model-${String(index + 1).padStart(2, "0")}`,
+        totalTokens: 110 - index * 10,
+      }),
+    );
+
+    const derived = deriveCharts(rows, range);
+
+    expect(derived.spendLegend.map((entry) => entry.series)).toEqual([
+      "model-01",
+      "model-02",
+      "model-03",
+      "model-04",
+      "model-05",
+      "model-06",
+      "model-07",
+      "model-08",
+      "model-09",
+      "Other",
+    ]);
+    expect(
+      derived.spendDays[0]?.segments.find((segment) => segment.series === "Other")?.value,
+    ).toBe(3);
   });
 });
 

--- a/apps/www/src/routes/design.tsx
+++ b/apps/www/src/routes/design.tsx
@@ -250,7 +250,7 @@ function DesignPage() {
           <StatCard label="Total spend" value="$1,284" />
           <StatCard label="Total tokens" value="48.2M" />
           <StatCard label="Active days" value="63" />
-          <StatCard label="Top spend model" value="Claude Opus 4.8" />
+          <StatCard label="Top spend model" value="claude-opus-4-8" />
         </div>
       </Section>
     </div>

--- a/apps/www/src/routes/og-card/$login.tsx
+++ b/apps/www/src/routes/og-card/$login.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 
-import { modelSeriesLabel } from "../../components/charts/scale";
 import { formatOgNumber, formatOgTokens, formatOgUsd } from "../../lib/og";
 import { loadProfileOgData, type ProfileOgData } from "../../lib/og-data";
 
@@ -75,7 +74,7 @@ function OgProfileHeader({ data }: { data: ProfileOgData }) {
 
 function StatsGrid({ data }: { data: ProfileOgData }) {
   const { stats } = data.profile;
-  const topSpendModel = stats.topModel === null ? "—" : modelSeriesLabel(stats.topModel.model);
+  const topSpendModel = stats.topModel === null ? "—" : stats.topModel.model;
   const metrics = [
     { label: "Total spend", value: formatOgUsd(stats.totalSpendUsd) },
     { label: "Total tokens", value: formatOgTokens(stats.totalTokens) },

--- a/apps/www/src/routes/stats.tsx
+++ b/apps/www/src/routes/stats.tsx
@@ -12,7 +12,7 @@ import {
   enumerateDays,
   formatTokens,
   formatUsd,
-  modelSeriesLabel,
+  selectModelSeries,
   seriesColors,
 } from "../components/charts/scale";
 import { Legend, StackedBars, type StackedDay } from "../components/charts/stacked-bars";
@@ -56,8 +56,6 @@ const CHART_MODES: { label: string; value: ChartMode }[] = [
   { label: "Usage", value: "absolute" },
   { label: "Share", value: "share" },
 ];
-const LEGEND_LIMIT = 10;
-
 const Route = createFileRoute("/stats")({
   validateSearch: statsSearchSchema,
   search: {
@@ -194,7 +192,7 @@ function TrendSection({ selected }: { selected: SelectedStats }) {
         <div className="mt-4 flex flex-col gap-6 lg:flex-row lg:items-center">
           <div className="min-w-0 flex-1">
             <StackedBars
-              ariaLabel={`Aggregate daily spend by model series across ${derived.spendDays.length} days`}
+              ariaLabel={`Aggregate daily spend by model across ${derived.spendDays.length} days`}
               days={derived.spendDays}
               highlight={hoveredSpendSeries}
               mode={chartMode}
@@ -210,7 +208,7 @@ function TrendSection({ selected }: { selected: SelectedStats }) {
         <div className="mt-4 flex flex-col gap-6 lg:flex-row lg:items-center">
           <div className="min-w-0 flex-1">
             <StackedBars
-              ariaLabel={`Aggregate daily tokens by model series across ${derived.tokenDays.length} days`}
+              ariaLabel={`Aggregate daily tokens by model across ${derived.tokenDays.length} days`}
               days={derived.tokenDays}
               highlight={hoveredTokensSeries}
               mode={chartMode}
@@ -226,7 +224,7 @@ function TrendSection({ selected }: { selected: SelectedStats }) {
         <div className="mt-4 flex flex-col gap-6 lg:flex-row lg:items-center">
           <div className="min-w-0 flex-1">
             <StackedBars
-              ariaLabel={`Aggregate daily sessions by model series across ${derived.sessionDays.length} days`}
+              ariaLabel={`Aggregate daily sessions by model across ${derived.sessionDays.length} days`}
               days={derived.sessionDays}
               highlight={hoveredSessionsSeries}
               mode={chartMode}
@@ -352,6 +350,9 @@ function deriveAggregateCharts(
   last: string | null,
 ) {
   const colors = seriesColors(rows);
+  const spendSelection = selectModelSeries(rows, (row) => row.costUsd);
+  const tokenSelection = selectModelSeries(rows, (row) => row.totalTokens);
+  const sessionSelection = selectModelSeries(rows, (row) => row.rowCount);
   const spendByDate = new Map<string, number>();
   const tokenByDate = new Map<string, number>();
   const sessionByDate = new Map<string, number>();
@@ -364,27 +365,40 @@ function deriveAggregateCharts(
     tokenByDate.set(row.date, (tokenByDate.get(row.date) ?? 0) + row.totalTokens);
     sessionByDate.set(row.date, (sessionByDate.get(row.date) ?? 0) + row.rowCount);
 
-    const series = modelSeriesLabel(row.key);
+    const spendModel = spendSelection.label(row.key);
     const spendSeries = spendSeriesByDate.get(row.date) ?? new Map<string, number>();
-    spendSeries.set(series, (spendSeries.get(series) ?? 0) + row.costUsd);
+    spendSeries.set(spendModel, (spendSeries.get(spendModel) ?? 0) + row.costUsd);
     spendSeriesByDate.set(row.date, spendSeries);
 
+    const tokenModel = tokenSelection.label(row.key);
     const tokenSeries = tokenSeriesByDate.get(row.date) ?? new Map<string, number>();
-    tokenSeries.set(series, (tokenSeries.get(series) ?? 0) + row.totalTokens);
+    tokenSeries.set(tokenModel, (tokenSeries.get(tokenModel) ?? 0) + row.totalTokens);
     tokenSeriesByDate.set(row.date, tokenSeries);
 
+    const sessionModel = sessionSelection.label(row.key);
     const sessionSeries = sessionSeriesByDate.get(row.date) ?? new Map<string, number>();
-    sessionSeries.set(series, (sessionSeries.get(series) ?? 0) + row.rowCount);
+    sessionSeries.set(sessionModel, (sessionSeries.get(sessionModel) ?? 0) + row.rowCount);
     sessionSeriesByDate.set(row.date, sessionSeries);
   }
 
   const days = first === null || last === null ? [] : enumerateDays(first, last);
-  const seriesOrder = [...colors.keys()];
-  const spendDays = buildStackedDays(days, seriesOrder, colors, spendSeriesByDate, spendByDate);
-  const tokenDays = buildStackedDays(days, seriesOrder, colors, tokenSeriesByDate, tokenByDate);
+  const spendDays = buildStackedDays(
+    days,
+    spendSelection.order,
+    colors,
+    spendSeriesByDate,
+    spendByDate,
+  );
+  const tokenDays = buildStackedDays(
+    days,
+    tokenSelection.order,
+    colors,
+    tokenSeriesByDate,
+    tokenByDate,
+  );
   const sessionDays = buildStackedDays(
     days,
-    seriesOrder,
+    sessionSelection.order,
     colors,
     sessionSeriesByDate,
     sessionByDate,
@@ -440,14 +454,7 @@ function buildLegend(days: readonly StackedDay[], colors: ReadonlyMap<string, st
     }))
     .filter((entry) => entry.value > 0)
     .sort((a, b) => b.value - a.value);
-  const other = entries.find((entry) => entry.series === "Other");
-  const namedEntries = entries.filter((entry) => entry.series !== "Other");
-  const visibleEntries =
-    other === undefined
-      ? namedEntries.slice(0, LEGEND_LIMIT)
-      : [...namedEntries.slice(0, LEGEND_LIMIT - 1), other];
-
-  return visibleEntries.map(({ color, percent, series }) => ({ color, percent, series }));
+  return entries.map(({ color, percent, series }) => ({ color, percent, series }));
 }
 
 function formatRange(totals: Totals): string {


### PR DESCRIPTION
## Summary

- replace the hard-coded model-family regex taxonomy with raw model names
- rank models across each selected chart window and keep at most 10 rendered series
- reserve the final slot for a real `Other` bucket only when lower-volume models overflow the limit
- show the exact top-spend model on profile and OG cards
- keep spend, token, and session top-model selections independent

Closes #37

## Verification

- `bun run test` (full monorepo via pre-commit hook)
- `bun run typecheck` (full monorepo via pre-commit hook)
- `bun run lint`
- `bun run fmt`
- `bun run build` in `apps/www`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/tokenmaxxing/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787336478&installation_model_id=428386&pr_number=43&repository=851-labs%2Ftokenmaxxing&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Ftokenmaxxing%2Fpull%2F43&signature=5446b431d723943d596f4164ef94da42fe1b16dcbea4e9402b112d9c82a4ab83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->