### PR TITLE
fix(cli): launch ccusage on Windows

### DIFF
--- a/apps/cli/src/ccusage/runner.test.ts
+++ b/apps/cli/src/ccusage/runner.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vitest";
 
-import { dailyCcusageCommand, sessionCcusageCommand } from "./runner";
+import {
+  CcusageRunError,
+  ccusageCommandInvocations,
+  dailyCcusageCommand,
+  execCcusage,
+  sessionCcusageCommand,
+} from "./runner";
 
 const codex = { source: "codex", subcommand: "codex" };
 
@@ -23,5 +30,63 @@ describe("ccusage commands", () => {
       "--mode",
       "calculate",
     ]);
+  });
+});
+
+describe("ccusageCommandInvocations", () => {
+  it("selects the Windows npm command shim", () => {
+    expect(ccusageCommandInvocations(["codex", "daily"], "win32")).toEqual([
+      { args: ["x", "ccusage@^20.0.17", "codex", "daily"], command: "bun" },
+      { args: ["-y", "ccusage@^20.0.17", "codex", "daily"], command: "npx.cmd" },
+    ]);
+  });
+
+  it("keeps the POSIX npm fallback", () => {
+    expect(ccusageCommandInvocations(["codex", "daily"], "linux")).toEqual([
+      { args: ["x", "ccusage@^20.0.17", "codex", "daily"], command: "bun" },
+      { args: ["-y", "ccusage@^20.0.17", "codex", "daily"], command: "npx" },
+    ]);
+  });
+});
+
+describe("execCcusage", () => {
+  it("returns a successful Bun result without invoking npm", async () => {
+    const run = vi.fn(() => Effect.succeed('{"daily":[]}'));
+
+    await expect(
+      Effect.runPromise(execCcusage(["codex", "daily"], "codex", { platform: "win32", run })),
+    ).resolves.toBe('{"daily":[]}');
+    expect(run).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledWith("bun", ["x", "ccusage@^20.0.17", "codex", "daily"]);
+  });
+
+  it("falls back to npx.cmd when Bun is missing on Windows", async () => {
+    const missingBun = new CcusageRunError({
+      cause: Object.assign(new Error("bun not found"), { code: "ENOENT" }),
+      source: "codex",
+    });
+    const run = vi
+      .fn()
+      .mockReturnValueOnce(Effect.fail(missingBun))
+      .mockReturnValueOnce(Effect.succeed('{"daily":[]}'));
+
+    await expect(
+      Effect.runPromise(execCcusage(["codex", "daily"], "codex", { platform: "win32", run })),
+    ).resolves.toBe('{"daily":[]}');
+    expect(run).toHaveBeenNthCalledWith(1, "bun", ["x", "ccusage@^20.0.17", "codex", "daily"]);
+    expect(run).toHaveBeenNthCalledWith(2, "npx.cmd", ["-y", "ccusage@^20.0.17", "codex", "daily"]);
+  });
+
+  it("does not mask a Bun execution failure with the npm fallback", async () => {
+    const failedBun = new CcusageRunError({
+      cause: Object.assign(new Error("bun x failed"), { code: 1 }),
+      source: "codex",
+    });
+    const run = vi.fn(() => Effect.fail(failedBun));
+
+    await expect(
+      Effect.runPromise(execCcusage(["codex", "daily"], "codex", { platform: "win32", run })),
+    ).rejects.toBeDefined();
+    expect(run).toHaveBeenCalledOnce();
   });
 });

--- a/apps/cli/src/ccusage/runner.ts
+++ b/apps/cli/src/ccusage/runner.ts
@@ -7,8 +7,8 @@ import { decodeDailyReport, decodeSessionReport } from "./schema";
 import type { CcusageSource } from "./sources";
 
 /**
- * Shells out to `bunx ccusage@^20.0.17 <source> daily --json --breakdown` (npx
- * fallback only when bunx itself is missing). A source that fails, is not
+ * Shells out to `bun x ccusage@^20.0.17 <source> daily --json --breakdown` (npx
+ * fallback only when bun itself is missing). A source that fails, is not
  * installed, or has no local data resolves to none — one broken agent must
  * never abort the whole sync.
  */
@@ -25,6 +25,21 @@ interface RunOptions {
   /** YYYY-MM-DD; forwarded to ccusage as compact YYYYMMDD. */
   since?: string | undefined;
 }
+
+interface CcusageCommandInvocation {
+  args: string[];
+  command: string;
+}
+
+interface ExecCcusageOptions {
+  platform?: NodeJS.Platform | undefined;
+  run?: CcusageCommandRunner | undefined;
+}
+
+type CcusageCommandRunner = (
+  command: string,
+  args: string[],
+) => Effect.Effect<string, CcusageRunError>;
 
 function runCcusageDailyReport(
   source: CcusageSource,
@@ -94,8 +109,23 @@ function sessionCcusageArgs(source: CcusageSource, options: RunOptions = {}): st
   return args;
 }
 
-function execCcusage(args: string[], source: string): Effect.Effect<string, CcusageRunError> {
-  const run = (command: string, commandArgs: string[]) =>
+function execCcusage(
+  args: string[],
+  source: string,
+  options: ExecCcusageOptions = {},
+): Effect.Effect<string, CcusageRunError> {
+  const run = options.run ?? makeCcusageCommandRunner(source);
+  const [primary, fallback] = ccusageCommandInvocations(args, options.platform ?? process.platform);
+
+  return run(primary.command, primary.args).pipe(
+    Effect.catch((error: CcusageRunError) =>
+      isMissingCommand(error.cause) ? run(fallback.command, fallback.args) : Effect.fail(error),
+    ),
+  );
+}
+
+function makeCcusageCommandRunner(source: string): CcusageCommandRunner {
+  return (command, commandArgs) =>
     Effect.callback<string, CcusageRunError>((resume) => {
       const child = execFile(
         command,
@@ -114,14 +144,21 @@ function execCcusage(args: string[], source: string): Effect.Effect<string, Ccus
         child.kill();
       });
     });
+}
 
-  return run("bunx", [CCUSAGE_SPEC, ...args]).pipe(
-    Effect.catch((error: CcusageRunError) =>
-      isMissingCommand(error.cause)
-        ? run("npx", ["-y", CCUSAGE_SPEC, ...args])
-        : Effect.fail(error),
-    ),
-  );
+function ccusageCommandInvocations(
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): [CcusageCommandInvocation, CcusageCommandInvocation] {
+  return [
+    { args: ["x", CCUSAGE_SPEC, ...args], command: "bun" },
+    {
+      args: ["-y", CCUSAGE_SPEC, ...args],
+      // The published Windows CLI is Bun-compiled, whose execFile implementation
+      // can launch npm's command shim directly. A Node runtime would need cmd.exe.
+      command: platform === "win32" ? "npx.cmd" : "npx",
+    },
+  ];
 }
 
 function isMissingCommand(cause: unknown): boolean {
@@ -129,7 +166,10 @@ function isMissingCommand(cause: unknown): boolean {
 }
 
 export {
+  CcusageRunError,
+  ccusageCommandInvocations,
   dailyCcusageCommand,
+  execCcusage,
   runCcusageDailyReport,
   runCcusageSessionReport,
   sessionCcusageCommand,


### PR DESCRIPTION
## Summary

- launch ccusage through `bun x` instead of relying on the separate `bunx` shim
- use npm's `npx.cmd` command shim for the Windows fallback while retaining `npx` elsewhere
- cover platform selection, successful Bun execution, missing-Bun fallback, and non-missing failures with focused tests

## Why

On Windows, npm-only installations can fail before ccusage starts because the direct subprocess fallback selects `npx` rather than the Windows `npx.cmd` shim. The sync path then treats that runner failure as unavailable source data and skips Codex.

This extracts the launcher fix proposed by @Pimpmuckl in #27 so it can be reviewed independently. It intentionally excludes the large-history upload chunking changes from that PR.

The published Windows CLI is Bun-compiled, and that runtime can launch `npx.cmd` directly. A future Node-based Windows runtime would need explicit `cmd.exe` handling.

## Validation

- `bun run --cwd apps/cli test -- src/ccusage/runner.test.ts`
- `bun run --cwd apps/cli test`
- `bun run --cwd apps/cli typecheck`
- full pre-commit formatting, workspace typechecking, linting, and tests

## Follow-up

- #45 tracks distinguishing ccusage runner failures from sources with no data
