### PR TITLE
Normalize ccusage model labels

### DIFF
--- a/apps/api/src/usage/ccusage.ts
+++ b/apps/api/src/usage/ccusage.ts
@@ -5,7 +5,7 @@ import type {
 } from "@tokenmaxxing/api-contract";
 import { Effect, Option, Schema } from "effect";
 
-const PARSER_VERSION = "ccusage-v20-raw-1";
+const PARSER_VERSION = "ccusage-v20-raw-2";
 
 const CcusageModelBreakdown = Schema.Struct({
   cacheCreationTokens: Schema.optional(Schema.Number),

--- a/apps/api/src/usage/models.test.ts
+++ b/apps/api/src/usage/models.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { UsageDayInput } from "@tokenmaxxing/api-contract";
+
+import { normalizeCcusageModelName, normalizeUsageDays } from "./models";
+
+describe("normalizeCcusageModelName", () => {
+  it.each([
+    ["pi", "[pi] gpt-5.5", "gpt-5.5"],
+    ["pi", "[PI]    gpt-5.5", "gpt-5.5"],
+    ["openclaw", "[openclaw]deepseek-v4", "deepseek-v4"],
+    ["pi", "gpt-5.5", "gpt-5.5"],
+    ["pi", "[preview] gpt-5.5", "[preview] gpt-5.5"],
+    ["pi", "[pi]   ", "[pi]   "],
+  ])("normalizes %s model %s as %s", (source, model, expected) => {
+    expect(normalizeCcusageModelName(source, model)).toBe(expected);
+  });
+});
+
+describe("normalizeUsageDays", () => {
+  it("merges canonical collisions after normalization", () => {
+    const rows = [
+      usageDay({
+        cacheReadTokens: 10,
+        costUsd: 2,
+        inputTokens: 20,
+        model: "[pi] gpt-5.5",
+        outputTokens: 30,
+        totalTokens: 60,
+      }),
+      usageDay({
+        cacheCreationTokens: 5,
+        costUsd: 3,
+        inputTokens: 40,
+        model: "gpt-5.5",
+        outputTokens: 50,
+        totalTokens: 95,
+      }),
+    ];
+
+    expect(normalizeUsageDays(rows)).toEqual([
+      usageDay({
+        cacheCreationTokens: 5,
+        cacheReadTokens: 10,
+        costUsd: 5,
+        inputTokens: 60,
+        model: "gpt-5.5",
+        outputTokens: 80,
+        totalTokens: 155,
+      }),
+    ]);
+  });
+
+  it("keeps identical model names separate across sources", () => {
+    const rows = [
+      usageDay({ model: "[pi] gpt-5.5" }),
+      usageDay({ model: "[openclaw] gpt-5.5", source: "openclaw" }),
+    ];
+
+    expect(normalizeUsageDays(rows)).toHaveLength(2);
+  });
+});
+
+function usageDay(overrides: Partial<UsageDayInput> = {}): UsageDayInput {
+  return {
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    costUsd: 0,
+    date: "2026-07-09",
+    inputTokens: 0,
+    model: "gpt-5.5",
+    outputTokens: 0,
+    source: "pi",
+    totalTokens: 0,
+    ...overrides,
+  };
+}

--- a/apps/api/src/usage/models.ts
+++ b/apps/api/src/usage/models.ts
@@ -1,0 +1,44 @@
+import type { UsageDayInput } from "@tokenmaxxing/api-contract";
+
+function normalizeCcusageModelName(source: string, model: string): string {
+  const prefix = /^\[([^\]]+)\]/.exec(model);
+  if (prefix?.[1]?.toLowerCase() !== source.toLowerCase()) {
+    return model;
+  }
+
+  const normalized = model.slice(prefix[0].length).trimStart();
+  return normalized.length === 0 ? model : normalized;
+}
+
+function normalizeUsageDays(days: readonly UsageDayInput[]): UsageDayInput[] {
+  const merged = new Map<string, UsageDayInput>();
+
+  for (const day of days) {
+    const model = normalizeCcusageModelName(day.source, day.model);
+    const key = JSON.stringify([day.date, day.source, model]);
+    const existing = merged.get(key);
+    if (existing === undefined) {
+      merged.set(key, { ...day, model });
+      continue;
+    }
+
+    merged.set(key, {
+      ...existing,
+      cacheCreationTokens: existing.cacheCreationTokens + day.cacheCreationTokens,
+      cacheReadTokens: existing.cacheReadTokens + day.cacheReadTokens,
+      costUsd: existing.costUsd + day.costUsd,
+      inputTokens: existing.inputTokens + day.inputTokens,
+      outputTokens: existing.outputTokens + day.outputTokens,
+      totalTokens: existing.totalTokens + day.totalTokens,
+    });
+  }
+
+  return [...merged.values()].sort(
+    (left, right) =>
+      left.date.localeCompare(right.date) ||
+      left.source.localeCompare(right.source) ||
+      left.model.localeCompare(right.model),
+  );
+}
+
+export { normalizeCcusageModelName, normalizeUsageDays };

--- a/apps/api/src/usage/service.test.ts
+++ b/apps/api/src/usage/service.test.ts
@@ -47,7 +47,7 @@ const rawReports: RawUsageReportInput[] = [
           costUSD: 12.34,
           date: "2026-06-15",
           models: {
-            "GPT-5.5": {
+            "[codex] GPT-5.5": {
               inputTokens: 100,
               outputTokens: 200,
               totalTokens: 300,
@@ -248,6 +248,42 @@ describe("UsageService.syncBatch", () => {
     );
   });
 
+  it("normalizes and merges legacy structured rows before upserting", async () => {
+    const { repository, upsertChunk } = makeRepository();
+    const service = await makeService(repository);
+    const prefixed = {
+      ...usageDay,
+      costUsd: 1,
+      inputTokens: 10,
+      model: "[codex] GPT-5.5",
+      outputTokens: 20,
+      totalTokens: 30,
+    };
+
+    const result = await Effect.runPromise(
+      service.syncBatch({ deviceId: "device_123", tokenId: "token_123", user }, device, [
+        prefixed,
+        usageDay,
+      ]),
+    );
+
+    expect(result).toMatchObject({ received: 2, upserted: 1 });
+    expect(upsertChunk).toHaveBeenCalledWith(
+      "user_123",
+      "device_123",
+      [
+        {
+          ...usageDay,
+          costUsd: 13.34,
+          inputTokens: 110,
+          outputTokens: 220,
+          totalTokens: 330,
+        },
+      ],
+      expect.any(Date),
+    );
+  });
+
   it("does not touch storage when the token has no device", async () => {
     const { repository, touchDevice, upsertChunk, upsertSourceStats } = makeRepository();
     const service = await makeService(repository);
@@ -287,6 +323,7 @@ describe("UsageService.ingestRaw", () => {
           ) as unknown as string,
           payloadBytes: JSON.stringify(rawReports[0]!.payload).length,
           payloadJson: JSON.stringify(rawReports[0]!.payload),
+          parserVersion: "ccusage-v20-raw-2",
           reportKind: "daily",
           source: "codex",
         }),

--- a/apps/api/src/usage/service.ts
+++ b/apps/api/src/usage/service.ts
@@ -18,6 +18,7 @@ import type {
 import { sha256Hex } from "../auth/crypto";
 import type { DatabaseError } from "../database";
 import { parseRawUsageReports, PARSER_VERSION } from "./ccusage";
+import { normalizeUsageDays } from "./models";
 import type { RawUsageStorageError } from "./raw-store";
 
 /**
@@ -168,7 +169,7 @@ const makeUsageService = Effect.fn("makeUsageService")(function* () {
         .pipe(Effect.orDie);
 
       const parsed = yield* parseRawUsageReports(reports);
-      yield* writeStructuredUsage(
+      const upserted = yield* writeStructuredUsage(
         repository,
         identity.user.id,
         deviceId,
@@ -181,7 +182,7 @@ const makeUsageService = Effect.fn("makeUsageService")(function* () {
       return {
         received: reports.length,
         syncedAt: syncedAt.toISOString(),
-        upserted: parsed.rows.length,
+        upserted,
       };
     }),
     syncBatch: Effect.fn("UsageService.syncBatch")(function* (
@@ -193,7 +194,7 @@ const makeUsageService = Effect.fn("makeUsageService")(function* () {
       const deviceId = yield* requireDeviceId(identity);
       const syncedAt = new Date();
 
-      yield* writeStructuredUsage(
+      const upserted = yield* writeStructuredUsage(
         repository,
         identity.user.id,
         deviceId,
@@ -206,7 +207,7 @@ const makeUsageService = Effect.fn("makeUsageService")(function* () {
       return {
         received: days.length,
         syncedAt: syncedAt.toISOString(),
-        upserted: days.length,
+        upserted,
       };
     }),
   });
@@ -294,13 +295,21 @@ function writeStructuredUsage(
   syncedAt: Date,
 ) {
   return Effect.gen(function* () {
-    for (let offset = 0; offset < days.length; offset += UPSERT_CHUNK_SIZE) {
+    const normalizedDays = normalizeUsageDays(days);
+    for (let offset = 0; offset < normalizedDays.length; offset += UPSERT_CHUNK_SIZE) {
       yield* repository
-        .upsertChunk(userId, deviceId, days.slice(offset, offset + UPSERT_CHUNK_SIZE), syncedAt)
+        .upsertChunk(
+          userId,
+          deviceId,
+          normalizedDays.slice(offset, offset + UPSERT_CHUNK_SIZE),
+          syncedAt,
+        )
         .pipe(Effect.orDie);
     }
     yield* repository.upsertSourceStats(userId, deviceId, sourceStats, syncedAt).pipe(Effect.orDie);
     yield* repository.touchDevice(deviceId, device, syncedAt).pipe(Effect.orDie);
+
+    return normalizedDays.length;
   });
 }
 

--- a/packages/db/migrations/0011_normalize_ccusage_model_labels.sql
+++ b/packages/db/migrations/0011_normalize_ccusage_model_labels.sql
@@ -1,0 +1,108 @@
+CREATE TABLE `_usage_days_normalized` AS
+WITH `normalized` AS (
+	SELECT
+		`device_id`,
+		`user_id`,
+		`date`,
+		`source`,
+		`model`,
+		CASE
+			WHEN lower(substr(`model`, 1, length(`source`) + 2)) = lower('[' || `source` || ']')
+				AND length(ltrim(substr(`model`, length(`source`) + 3))) > 0
+			THEN ltrim(substr(`model`, length(`source`) + 3))
+			ELSE `model`
+		END AS `normalized_model`,
+		`input_tokens`,
+		`output_tokens`,
+		`cache_creation_tokens`,
+		`cache_read_tokens`,
+		`total_tokens`,
+		`cost_usd`,
+		`synced_at`
+	FROM `usage_days`
+),
+`affected_keys` AS (
+	SELECT DISTINCT
+		`device_id`,
+		`date`,
+		`source`,
+		`normalized_model`
+	FROM `normalized`
+	WHERE `model` <> `normalized_model`
+),
+`latest` AS (
+	SELECT
+		`normalized`.*,
+		max(`normalized`.`synced_at`) OVER (
+			PARTITION BY
+				`normalized`.`device_id`,
+				`normalized`.`date`,
+				`normalized`.`source`,
+				`normalized`.`normalized_model`
+		) AS `latest_synced_at`
+	FROM `normalized`
+	INNER JOIN `affected_keys`
+		ON `affected_keys`.`device_id` = `normalized`.`device_id`
+		AND `affected_keys`.`date` = `normalized`.`date`
+		AND `affected_keys`.`source` = `normalized`.`source`
+		AND `affected_keys`.`normalized_model` = `normalized`.`normalized_model`
+)
+SELECT
+	`device_id`,
+	max(`user_id`) AS `user_id`,
+	`date`,
+	`source`,
+	`normalized_model` AS `model`,
+	sum(`input_tokens`) AS `input_tokens`,
+	sum(`output_tokens`) AS `output_tokens`,
+	sum(`cache_creation_tokens`) AS `cache_creation_tokens`,
+	sum(`cache_read_tokens`) AS `cache_read_tokens`,
+	sum(`total_tokens`) AS `total_tokens`,
+	sum(`cost_usd`) AS `cost_usd`,
+	`latest_synced_at` AS `synced_at`
+FROM `latest`
+WHERE `synced_at` = `latest_synced_at`
+GROUP BY `device_id`, `date`, `source`, `normalized_model`, `latest_synced_at`;--> statement-breakpoint
+DELETE FROM `usage_days`
+WHERE EXISTS (
+	SELECT 1
+	FROM `_usage_days_normalized`
+	WHERE `_usage_days_normalized`.`device_id` = `usage_days`.`device_id`
+		AND `_usage_days_normalized`.`date` = `usage_days`.`date`
+		AND `_usage_days_normalized`.`source` = `usage_days`.`source`
+		AND `_usage_days_normalized`.`model` = CASE
+			WHEN lower(substr(`usage_days`.`model`, 1, length(`usage_days`.`source`) + 2)) = lower('[' || `usage_days`.`source` || ']')
+				AND length(ltrim(substr(`usage_days`.`model`, length(`usage_days`.`source`) + 3))) > 0
+			THEN ltrim(substr(`usage_days`.`model`, length(`usage_days`.`source`) + 3))
+			ELSE `usage_days`.`model`
+		END
+);--> statement-breakpoint
+INSERT INTO `usage_days` (
+	`device_id`,
+	`user_id`,
+	`date`,
+	`source`,
+	`model`,
+	`input_tokens`,
+	`output_tokens`,
+	`cache_creation_tokens`,
+	`cache_read_tokens`,
+	`total_tokens`,
+	`cost_usd`,
+	`synced_at`
+)
+SELECT
+	`device_id`,
+	`user_id`,
+	`date`,
+	`source`,
+	`model`,
+	`input_tokens`,
+	`output_tokens`,
+	`cache_creation_tokens`,
+	`cache_read_tokens`,
+	`total_tokens`,
+	`cost_usd`,
+	`synced_at`
+FROM `_usage_days_normalized`;--> statement-breakpoint
+DROP TABLE `_usage_days_normalized`;

--- a/packages/db/migrations/meta/0011_snapshot.json
+++ b/packages/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1050 @@
+{
+  "id": "2489ff70-7dbe-4060-a733-237f6b84ac0b",
+  "prevId": "dcaab926-332d-4c0b-89a7-109bb675033d",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "cli_login_requests": {
+      "name": "cli_login_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_platform": {
+          "name": "device_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_arch": {
+          "name": "device_arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_version": {
+          "name": "device_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cli_login_requests_code_unique": {
+          "name": "cli_login_requests_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cli_login_requests_user_id_users_id_fk": {
+          "name": "cli_login_requests_user_id_users_id_fk",
+          "tableFrom": "cli_login_requests",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cli_tokens": {
+      "name": "cli_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cli_tokens_token_hash_unique": {
+          "name": "cli_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "cli_tokens_user_idx": {
+          "name": "cli_tokens_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cli_tokens_user_id_users_id_fk": {
+          "name": "cli_tokens_user_id_users_id_fk",
+          "tableFrom": "cli_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "devices": {
+      "name": "devices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_check_in_at": {
+          "name": "last_check_in_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_attempted_at": {
+          "name": "service_auto_update_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_completed_at": {
+          "name": "service_auto_update_completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_current_version": {
+          "name": "service_auto_update_current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_enabled": {
+          "name": "service_auto_update_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_error": {
+          "name": "service_auto_update_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_installed_version": {
+          "name": "service_auto_update_installed_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_latest_version": {
+          "name": "service_auto_update_latest_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_manager": {
+          "name": "service_auto_update_manager",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_reason": {
+          "name": "service_auto_update_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_auto_update_status": {
+          "name": "service_auto_update_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_backend": {
+          "name": "service_backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_error": {
+          "name": "service_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_reload_required": {
+          "name": "service_reload_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_repair_attempted_at": {
+          "name": "service_repair_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_repair_completed_at": {
+          "name": "service_repair_completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_repair_error": {
+          "name": "service_repair_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_repair_reason": {
+          "name": "service_repair_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_repair_status": {
+          "name": "service_repair_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_runner_target": {
+          "name": "service_runner_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_runner_version": {
+          "name": "service_runner_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_scheduler_active": {
+          "name": "service_scheduler_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_status": {
+          "name": "service_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_template_version": {
+          "name": "service_template_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "devices_user_idx": {
+          "name": "devices_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "devices_user_id_users_id_fk": {
+          "name": "devices_user_id_users_id_fk",
+          "tableFrom": "devices",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_days": {
+      "name": "usage_days",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_days_user_date_idx": {
+          "name": "usage_days_user_date_idx",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "usage_days_date_idx": {
+          "name": "usage_days_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_days_device_id_date_source_model_pk": {
+          "columns": [
+            "device_id",
+            "date",
+            "source",
+            "model"
+          ],
+          "name": "usage_days_device_id_date_source_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_raw_batches": {
+      "name": "usage_raw_batches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report_kind": {
+          "name": "report_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ccusage_command": {
+          "name": "ccusage_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_bytes": {
+          "name": "payload_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parser_version": {
+          "name": "parser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_raw_batches_device_payload_hash_unique": {
+          "name": "usage_raw_batches_device_payload_hash_unique",
+          "columns": [
+            "device_id",
+            "payload_hash"
+          ],
+          "isUnique": true
+        },
+        "usage_raw_batches_user_idx": {
+          "name": "usage_raw_batches_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "usage_raw_batches_device_idx": {
+          "name": "usage_raw_batches_device_idx",
+          "columns": [
+            "device_id"
+          ],
+          "isUnique": false
+        },
+        "usage_raw_batches_source_idx": {
+          "name": "usage_raw_batches_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_source_stats": {
+      "name": "usage_source_stats",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_source_stats_user_idx": {
+          "name": "usage_source_stats_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_source_stats_device_id_source_pk": {
+          "columns": [
+            "device_id",
+            "source"
+          ],
+          "name": "usage_source_stats_device_id_source_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_accounts": {
+      "name": "user_accounts",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_accounts_user_idx": {
+          "name": "user_accounts_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_accounts_email_idx": {
+          "name": "user_accounts_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_accounts_user_id_users_id_fk": {
+          "name": "user_accounts_user_id_users_id_fk",
+          "tableFrom": "user_accounts",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_accounts_provider_provider_account_id_pk": {
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "name": "user_accounts_provider_provider_account_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shadow_banned_at": {
+          "name": "shadow_banned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shadow_banned_by_user_id": {
+          "name": "shadow_banned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_login_unique": {
+          "name": "users_login_unique",
+          "columns": [
+            "login"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1783656511551,
       "tag": "0010_mysterious_the_liberteens",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1784745303894,
+      "tag": "0011_normalize_ccusage_model_labels",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/normalize-ccusage-model-labels.test.ts
+++ b/packages/db/src/normalize-ccusage-model-labels.test.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  new URL("../migrations/0011_normalize_ccusage_model_labels.sql", import.meta.url),
+  "utf8",
+);
+
+describe("normalize ccusage model labels migration", () => {
+  let database: DatabaseSync;
+
+  beforeEach(() => {
+    database = new DatabaseSync(":memory:");
+    database.exec(`
+      CREATE TABLE usage_days (
+        device_id text NOT NULL,
+        user_id text NOT NULL,
+        date text NOT NULL,
+        source text NOT NULL,
+        model text NOT NULL,
+        input_tokens integer DEFAULT 0 NOT NULL,
+        output_tokens integer DEFAULT 0 NOT NULL,
+        cache_creation_tokens integer DEFAULT 0 NOT NULL,
+        cache_read_tokens integer DEFAULT 0 NOT NULL,
+        total_tokens integer DEFAULT 0 NOT NULL,
+        cost_usd real DEFAULT 0 NOT NULL,
+        synced_at integer NOT NULL,
+        PRIMARY KEY(device_id, date, source, model)
+      );
+      CREATE INDEX usage_days_user_date_idx ON usage_days (user_id, date);
+      CREATE INDEX usage_days_date_idx ON usage_days (date);
+    `);
+  });
+
+  afterEach(() => database.close());
+
+  it("normalizes existing rows while preserving the latest daily snapshot", () => {
+    insertUsage({ date: "2026-07-01", model: "[pi] gpt-5.5", totalTokens: 10 });
+    insertUsage({ date: "2026-07-02", model: "[preview] gpt-5.5", totalTokens: 20 });
+    insertUsage({ date: "2026-07-03", model: "[pi]   ", totalTokens: 30 });
+    insertUsage({
+      date: "2026-07-04",
+      model: "[pi] gpt-5.5",
+      syncedAt: 100,
+      totalTokens: 100,
+    });
+    insertUsage({
+      date: "2026-07-04",
+      model: "gpt-5.5",
+      syncedAt: 200,
+      totalTokens: 200,
+    });
+    insertUsage({
+      date: "2026-07-05",
+      model: "deepseek-v4",
+      syncedAt: 200,
+      totalTokens: 500,
+    });
+    insertUsage({
+      date: "2026-07-05",
+      model: "[pi] deepseek-v4",
+      syncedAt: 300,
+      totalTokens: 30,
+    });
+    insertUsage({
+      date: "2026-07-05",
+      model: "[PI]deepseek-v4",
+      syncedAt: 300,
+      totalTokens: 40,
+    });
+
+    runMigration();
+
+    expect(
+      database
+        .prepare(
+          "select date, model, total_tokens as totalTokens, synced_at as syncedAt from usage_days order by date, model",
+        )
+        .all(),
+    ).toEqual([
+      { date: "2026-07-01", model: "gpt-5.5", syncedAt: 100, totalTokens: 10 },
+      { date: "2026-07-02", model: "[preview] gpt-5.5", syncedAt: 100, totalTokens: 20 },
+      { date: "2026-07-03", model: "[pi]   ", syncedAt: 100, totalTokens: 30 },
+      { date: "2026-07-04", model: "gpt-5.5", syncedAt: 200, totalTokens: 200 },
+      { date: "2026-07-05", model: "deepseek-v4", syncedAt: 300, totalTokens: 70 },
+    ]);
+    expect(
+      database
+        .prepare(
+          `select
+            input_tokens as inputTokens,
+            output_tokens as outputTokens,
+            cache_creation_tokens as cacheCreationTokens,
+            cache_read_tokens as cacheReadTokens,
+            cost_usd as costUsd
+          from usage_days where date = '2026-07-05'`,
+        )
+        .get(),
+    ).toEqual({
+      cacheCreationTokens: 70,
+      cacheReadTokens: 70,
+      costUsd: 70,
+      inputTokens: 70,
+      outputTokens: 70,
+    });
+  });
+
+  it("keeps the primary key and query indexes in place", () => {
+    insertUsage({ date: "2026-07-01", model: "[pi] gpt-5.5", totalTokens: 10 });
+
+    runMigration();
+
+    const indexes = database
+      .prepare("select name from sqlite_master where type = 'index' and tbl_name = 'usage_days'")
+      .all()
+      .map((row) => row.name);
+    expect(indexes).toEqual(
+      expect.arrayContaining(["usage_days_date_idx", "usage_days_user_date_idx"]),
+    );
+    expect(() => insertUsage({ date: "2026-07-01", model: "gpt-5.5", totalTokens: 20 })).toThrow();
+  });
+
+  function insertUsage({
+    date,
+    model,
+    syncedAt = 100,
+    totalTokens,
+  }: {
+    date: string;
+    model: string;
+    syncedAt?: number;
+    totalTokens: number;
+  }) {
+    database
+      .prepare(
+        `insert into usage_days (
+          device_id, user_id, date, source, model, input_tokens, output_tokens,
+          cache_creation_tokens, cache_read_tokens, total_tokens, cost_usd, synced_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "device_123",
+        "user_123",
+        date,
+        "pi",
+        model,
+        totalTokens,
+        totalTokens,
+        totalTokens,
+        totalTokens,
+        totalTokens,
+        totalTokens,
+        syncedAt,
+      );
+  }
+
+  function runMigration() {
+    for (const statement of migration.split("--> statement-breakpoint")) {
+      database.exec(statement);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- strip redundant leading `[source]` prefixes from ccusage model labels on the server
- normalize and merge canonical collisions for both raw ingestion and legacy structured sync
- preserve the original ccusage JSON in R2 and bump the structured parser version
- migrate existing `usage_days` rows without rewriting unrelated model keys

## Historical collision handling

When prefixed and canonical rows collapse to the same `(device, date, source, model)` key, the migration keeps the greatest `synced_at` snapshot. Rows tied within that latest snapshot are summed so variants emitted together remain additive.

Closes #31

## Verification

- `bun run test` (318 tests)
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/tokenmaxxing/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787337500&installation_model_id=428386&pr_number=48&repository=851-labs%2Ftokenmaxxing&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Ftokenmaxxing%2Fpull%2F48&signature=753a2ede4e504f06b1f3bbb76492908e2be47a26b716d8dba62bbe51fb9d47a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->