### PR TITLE
fix(cli): surface ccusage source failures

### DIFF
--- a/apps/cli/src/ccusage/runner.test.ts
+++ b/apps/cli/src/ccusage/runner.test.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Cause, Effect, Option } from "effect";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -6,10 +6,27 @@ import {
   ccusageCommandInvocations,
   dailyCcusageCommand,
   execCcusage,
+  runCcusageDailyReport,
   sessionCcusageCommand,
 } from "./runner";
 
 const codex = { source: "codex", subcommand: "codex" };
+
+async function ccusageErrorFor<A>(effect: Effect.Effect<A, CcusageRunError>) {
+  const exit = await Effect.runPromiseExit(effect);
+  expect(exit._tag).toBe("Failure");
+  if (exit._tag !== "Failure") {
+    throw new Error("expected ccusage failure");
+  }
+
+  const error = Cause.findErrorOption(exit.cause);
+  expect(Option.isSome(error)).toBe(true);
+  if (Option.isNone(error) || !(error.value instanceof CcusageRunError)) {
+    throw new Error("expected typed ccusage error");
+  }
+
+  return error.value;
+}
 
 describe("ccusage commands", () => {
   it("uses the minimum v20 release verified for GPT-5.6", () => {
@@ -54,7 +71,9 @@ describe("execCcusage", () => {
     const run = vi.fn(() => Effect.succeed('{"daily":[]}'));
 
     await expect(
-      Effect.runPromise(execCcusage(["codex", "daily"], "codex", { platform: "win32", run })),
+      Effect.runPromise(
+        execCcusage(["codex", "daily"], "codex", "daily", { platform: "win32", run }),
+      ),
     ).resolves.toBe('{"daily":[]}');
     expect(run).toHaveBeenCalledOnce();
     expect(run).toHaveBeenCalledWith("bun", ["x", "ccusage@^20.0.17", "codex", "daily"]);
@@ -63,6 +82,8 @@ describe("execCcusage", () => {
   it("falls back to npx.cmd when Bun is missing on Windows", async () => {
     const missingBun = new CcusageRunError({
       cause: Object.assign(new Error("bun not found"), { code: "ENOENT" }),
+      code: "command_not_found",
+      report: "daily",
       source: "codex",
     });
     const run = vi
@@ -71,7 +92,9 @@ describe("execCcusage", () => {
       .mockReturnValueOnce(Effect.succeed('{"daily":[]}'));
 
     await expect(
-      Effect.runPromise(execCcusage(["codex", "daily"], "codex", { platform: "win32", run })),
+      Effect.runPromise(
+        execCcusage(["codex", "daily"], "codex", "daily", { platform: "win32", run }),
+      ),
     ).resolves.toBe('{"daily":[]}');
     expect(run).toHaveBeenNthCalledWith(1, "bun", ["x", "ccusage@^20.0.17", "codex", "daily"]);
     expect(run).toHaveBeenNthCalledWith(2, "npx.cmd", ["-y", "ccusage@^20.0.17", "codex", "daily"]);
@@ -80,13 +103,66 @@ describe("execCcusage", () => {
   it("does not mask a Bun execution failure with the npm fallback", async () => {
     const failedBun = new CcusageRunError({
       cause: Object.assign(new Error("bun x failed"), { code: 1 }),
+      code: "command_failed",
+      report: "daily",
       source: "codex",
     });
     const run = vi.fn(() => Effect.fail(failedBun));
 
-    await expect(
-      Effect.runPromise(execCcusage(["codex", "daily"], "codex", { platform: "win32", run })),
-    ).rejects.toBeDefined();
+    const error = await ccusageErrorFor(
+      execCcusage(["codex", "daily"], "codex", "daily", { platform: "win32", run }),
+    );
+    expect(error).toBe(failedBun);
     expect(run).toHaveBeenCalledOnce();
+  });
+
+  it("classifies command timeouts without trying the npm fallback", async () => {
+    const run = vi.fn(() => Effect.never);
+
+    const error = await ccusageErrorFor(
+      execCcusage(["codex", "daily"], "codex", "daily", {
+        platform: "win32",
+        run,
+        timeoutMs: 1,
+      }),
+    );
+
+    expect(error.code).toBe("command_timed_out");
+    expect(error.report).toBe("daily");
+    expect(run).toHaveBeenCalledOnce();
+  });
+});
+
+describe("runCcusageDailyReport", () => {
+  it("returns valid empty reports as data instead of a runner failure", async () => {
+    const report = await Effect.runPromise(
+      runCcusageDailyReport(codex, {
+        exec: { run: () => Effect.succeed('{"daily":[]}') },
+      }),
+    );
+
+    expect(report).toEqual({ daily: [] });
+  });
+
+  it("classifies malformed JSON", async () => {
+    const error = await ccusageErrorFor(
+      runCcusageDailyReport(codex, {
+        exec: { run: () => Effect.succeed("not json") },
+      }),
+    );
+
+    expect(error.code).toBe("invalid_json");
+    expect(error.report).toBe("daily");
+  });
+
+  it("classifies JSON that does not match the report schema", async () => {
+    const error = await ccusageErrorFor(
+      runCcusageDailyReport(codex, {
+        exec: { run: () => Effect.succeed('{"sessions":[]}') },
+      }),
+    );
+
+    expect(error.code).toBe("invalid_report");
+    expect(error.report).toBe("daily");
   });
 });

--- a/apps/cli/src/ccusage/runner.ts
+++ b/apps/cli/src/ccusage/runner.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 
-import { Data, Effect, Option } from "effect";
+import { Data, Effect } from "effect";
 
 import type { CcusageDailyReport, CcusageSessionReport } from "./schema";
 import { decodeDailyReport, decodeSessionReport } from "./schema";
@@ -8,9 +8,8 @@ import type { CcusageSource } from "./sources";
 
 /**
  * Shells out to `bun x ccusage@^20.0.17 <source> daily --json --breakdown` (npx
- * fallback only when bun itself is missing). A source that fails, is not
- * installed, or has no local data resolves to none — one broken agent must
- * never abort the whole sync.
+ * fallback only when bun itself is missing). Runner and report failures stay
+ * typed so the sync layer can distinguish them from valid empty reports.
  */
 
 const CCUSAGE_SPEC = "ccusage@^20.0.17";
@@ -18,11 +17,14 @@ const RUN_TIMEOUT_MS = 180_000;
 
 class CcusageRunError extends Data.TaggedError("CcusageRunError")<{
   readonly cause: unknown;
+  readonly code: CcusageRunErrorCode;
+  readonly report: CcusageReportKind;
   readonly source: string;
 }> {}
 
 interface RunOptions {
   /** YYYY-MM-DD; forwarded to ccusage as compact YYYYMMDD. */
+  exec?: ExecCcusageOptions | undefined;
   since?: string | undefined;
 }
 
@@ -34,7 +36,16 @@ interface CcusageCommandInvocation {
 interface ExecCcusageOptions {
   platform?: NodeJS.Platform | undefined;
   run?: CcusageCommandRunner | undefined;
+  timeoutMs?: number | undefined;
 }
+
+type CcusageReportKind = "daily" | "session";
+type CcusageRunErrorCode =
+  | "command_failed"
+  | "command_not_found"
+  | "command_timed_out"
+  | "invalid_json"
+  | "invalid_report";
 
 type CcusageCommandRunner = (
   command: string,
@@ -44,43 +55,59 @@ type CcusageCommandRunner = (
 function runCcusageDailyReport(
   source: CcusageSource,
   options: RunOptions = {},
-): Effect.Effect<Option.Option<CcusageDailyReport>> {
+): Effect.Effect<CcusageDailyReport, CcusageRunError> {
   // calculate mode prices every token at current list rates ("API-equivalent
   // cost") — auto mode trusts pre-recorded costs, which subscription usage
   // records as $0 and would zero out codex/opencode on the leaderboard.
   const args = dailyCcusageArgs(source, options);
 
-  return Effect.gen(function* () {
-    const stdout = yield* execCcusage(args, source.source);
-    const report = yield* decodeDailyReport(JSON.parse(stdout)).pipe(
-      Effect.mapError((cause) => new CcusageRunError({ cause, source: source.source })),
-    );
-
-    return Option.some(report);
-  }).pipe(
-    // Missing runner, no data dir, malformed output: skip the source.
-    Effect.catchCause(() => Effect.succeedNone),
+  return execCcusage(args, source.source, "daily", options.exec).pipe(
+    Effect.flatMap((stdout) => decodeCcusageJson(stdout, source.source, "daily")),
+    Effect.flatMap((payload) =>
+      decodeDailyReport(payload).pipe(
+        Effect.mapError(
+          (cause) =>
+            new CcusageRunError({
+              cause,
+              code: "invalid_report",
+              report: "daily",
+              source: source.source,
+            }),
+        ),
+      ),
+    ),
   );
 }
 
 function runCcusageSessionReport(
   source: CcusageSource,
   options: RunOptions = {},
-): Effect.Effect<Option.Option<CcusageSessionReport>> {
+): Effect.Effect<CcusageSessionReport, CcusageRunError> {
   const args = sessionCcusageArgs(source, options);
 
-  return Effect.gen(function* () {
-    const stdout = yield* execCcusage(args, source.source);
-    const report = yield* decodeSessionReport(JSON.parse(stdout)).pipe(
-      Effect.mapError((cause) => new CcusageRunError({ cause, source: source.source })),
-    );
-
-    return Option.some(report);
-  }).pipe(
-    // Missing runner, no session support, no data dir, malformed output:
-    // show an unknown session count without failing usage sync.
-    Effect.catchCause(() => Effect.succeedNone),
+  return execCcusage(args, source.source, "session", options.exec).pipe(
+    Effect.flatMap((stdout) => decodeCcusageJson(stdout, source.source, "session")),
+    Effect.flatMap((payload) =>
+      decodeSessionReport(payload).pipe(
+        Effect.mapError(
+          (cause) =>
+            new CcusageRunError({
+              cause,
+              code: "invalid_report",
+              report: "session",
+              source: source.source,
+            }),
+        ),
+      ),
+    ),
   );
+}
+
+function decodeCcusageJson(stdout: string, source: string, report: CcusageReportKind) {
+  return Effect.try({
+    try: () => JSON.parse(stdout) as unknown,
+    catch: (cause) => new CcusageRunError({ cause, code: "invalid_json", report, source }),
+  });
 }
 
 function dailyCcusageCommand(source: CcusageSource, options: RunOptions = {}): string[] {
@@ -112,28 +139,52 @@ function sessionCcusageArgs(source: CcusageSource, options: RunOptions = {}): st
 function execCcusage(
   args: string[],
   source: string,
+  report: CcusageReportKind,
   options: ExecCcusageOptions = {},
 ): Effect.Effect<string, CcusageRunError> {
-  const run = options.run ?? makeCcusageCommandRunner(source);
+  const run = options.run ?? makeCcusageCommandRunner(source, report);
   const [primary, fallback] = ccusageCommandInvocations(args, options.platform ?? process.platform);
+  const runInvocation = (invocation: CcusageCommandInvocation) =>
+    run(invocation.command, invocation.args).pipe(
+      Effect.timeout(`${Math.max(1, options.timeoutMs ?? RUN_TIMEOUT_MS)} millis`),
+      Effect.mapError((error) =>
+        error instanceof CcusageRunError
+          ? error
+          : new CcusageRunError({
+              cause: error,
+              code: "command_timed_out",
+              report,
+              source,
+            }),
+      ),
+    );
 
-  return run(primary.command, primary.args).pipe(
+  return runInvocation(primary).pipe(
     Effect.catch((error: CcusageRunError) =>
-      isMissingCommand(error.cause) ? run(fallback.command, fallback.args) : Effect.fail(error),
+      error.code === "command_not_found" ? runInvocation(fallback) : Effect.fail(error),
     ),
   );
 }
 
-function makeCcusageCommandRunner(source: string): CcusageCommandRunner {
+function makeCcusageCommandRunner(source: string, report: CcusageReportKind): CcusageCommandRunner {
   return (command, commandArgs) =>
     Effect.callback<string, CcusageRunError>((resume) => {
       const child = execFile(
         command,
         commandArgs,
-        { maxBuffer: 256 * 1024 * 1024, timeout: RUN_TIMEOUT_MS },
+        { maxBuffer: 256 * 1024 * 1024 },
         (error, stdout) => {
           if (error) {
-            resume(Effect.fail(new CcusageRunError({ cause: error, source })));
+            resume(
+              Effect.fail(
+                new CcusageRunError({
+                  cause: error,
+                  code: isMissingCommand(error) ? "command_not_found" : "command_failed",
+                  report,
+                  source,
+                }),
+              ),
+            );
           } else {
             resume(Effect.succeed(stdout));
           }
@@ -175,4 +226,4 @@ export {
   sessionCcusageCommand,
 };
 
-export type { RunOptions };
+export type { CcusageReportKind, CcusageRunErrorCode, RunOptions };

--- a/apps/cli/src/commands/service.test.ts
+++ b/apps/cli/src/commands/service.test.ts
@@ -679,6 +679,7 @@ describe("serviceStateJson", () => {
           status: "synced",
         },
       ],
+      lastSyncStatus: "ok",
       lastSuccessAt: "2026-06-16T10:00:01.000Z",
       lastUpserted: 42,
       version: 1,
@@ -1393,9 +1394,10 @@ describe("service run state", () => {
     sourceResults: [
       {
         source: "codex",
+        status: "synced",
         summary: { days: 3, models: 2, rows: 42, sessions: null, spendUsd: 12.34 },
       },
-      { source: "gemini", summary: null },
+      { reason: "no_data", source: "gemini", status: "skipped", summary: null },
     ],
     sources: {
       codex: { days: 3, models: 2, rows: 42, sessions: null, spendUsd: 12.34 },
@@ -1437,6 +1439,7 @@ describe("service run state", () => {
       lastRows: 42,
       lastSince: "2026-06-16",
       lastSuccessAt: "2026-06-16T10:00:01.000Z",
+      lastSyncStatus: "ok",
       lastUpserted: 40,
       version: 1,
     });
@@ -1451,6 +1454,123 @@ describe("service run state", () => {
         status: "synced",
       },
       { source: "gemini", status: "skipped" },
+    ]);
+  });
+
+  it("records source collection failures without advancing the last success", () => {
+    const failedResult: SyncResult = {
+      dryRun: false,
+      rows: 0,
+      sourceResults: [
+        {
+          issue: {
+            code: "command_not_found",
+            message: "ccusage command not found",
+            report: "daily",
+          },
+          source: "codex",
+          status: "failed",
+          summary: null,
+        },
+      ],
+      sources: { codex: null },
+      status: "error",
+    };
+
+    const state = serviceRunSuccessState(
+      {
+        lastSuccessAt: "2026-06-16T09:00:00.000Z",
+        version: 1,
+      },
+      {
+        arch: "arm64",
+        attemptAt: "2026-06-16T10:00:00.000Z",
+        autoUpdate: autoUpdateReport(),
+        durationMs: 1234,
+        result: failedResult,
+        successAt: "2026-06-16T10:00:01.000Z",
+        version: "0.4.23",
+      },
+    );
+
+    expect(state).toMatchObject({
+      lastError: "ccusage source collection failed",
+      lastRows: 0,
+      lastSuccessAt: "2026-06-16T09:00:00.000Z",
+      lastSyncStatus: "error",
+      lastUpserted: 0,
+    });
+    expect(state.lastSources).toEqual([
+      {
+        issue: {
+          code: "command_not_found",
+          message: "ccusage command not found",
+          report: "daily",
+        },
+        source: "codex",
+        status: "failed",
+      },
+    ]);
+  });
+
+  it("records partial source diagnostics while advancing the last success", () => {
+    const partialResult: SyncResult = {
+      dryRun: false,
+      rows: 42,
+      sourceResults: [
+        {
+          issue: {
+            code: "invalid_report",
+            message: "ccusage returned an invalid session report",
+            report: "session",
+          },
+          source: "codex",
+          status: "partial",
+          summary: { days: 3, models: 2, rows: 42, sessions: null, spendUsd: 12.34 },
+        },
+      ],
+      sources: {
+        codex: { days: 3, models: 2, rows: 42, sessions: null, spendUsd: 12.34 },
+      },
+      status: "partial",
+      upserted: 40,
+    };
+
+    const state = serviceRunSuccessState(
+      { version: 1 },
+      {
+        arch: "arm64",
+        attemptAt: "2026-06-16T10:00:00.000Z",
+        autoUpdate: autoUpdateReport(),
+        durationMs: 1234,
+        result: partialResult,
+        successAt: "2026-06-16T10:00:01.000Z",
+        version: "0.4.23",
+      },
+    );
+
+    expect(state).toMatchObject({
+      lastError: undefined,
+      lastRows: 42,
+      lastSuccessAt: "2026-06-16T10:00:01.000Z",
+      lastSyncStatus: "partial",
+      lastUpserted: 40,
+    });
+    expect(state.lastSources).toEqual([
+      {
+        days: 3,
+        issue: {
+          code: "invalid_report",
+          message: "ccusage returned an invalid session report",
+          report: "session",
+        },
+        models: 2,
+        rows: 42,
+        sessions: null,
+        source: "codex",
+        spendUsd: 12.34,
+        status: "partial",
+      },
     ]);
   });
 

--- a/apps/cli/src/commands/service.ts
+++ b/apps/cli/src/commands/service.ts
@@ -50,6 +50,8 @@ import {
   syncProgram,
   type SyncAuth,
   type SyncResult,
+  type SyncSourceIssue,
+  type SyncStatus,
   type UploadRetryPolicy,
 } from "./sync";
 
@@ -237,6 +239,7 @@ interface ServiceState {
   lastSchedulerActive?: boolean;
   lastSince?: string;
   lastSources?: ServiceSourceState[];
+  lastSyncStatus?: SyncStatus;
   lastSuccessAt?: string;
   lastSuccessDate?: string;
   lastUpserted?: number;
@@ -246,12 +249,13 @@ interface ServiceState {
 
 interface ServiceSourceState {
   days?: number;
+  issue?: SyncSourceIssue;
   models?: number;
   rows?: number;
   sessions?: number | null;
   source: string;
   spendUsd?: number;
-  status: "skipped" | "synced";
+  status: "failed" | "partial" | "skipped" | "synced";
 }
 
 interface ServiceLogWriter {
@@ -898,6 +902,7 @@ function serviceStatusEffect(options: { json?: boolean | undefined } = {}) {
         lastSchedulerActive: state?.lastSchedulerActive ?? null,
         lastSince: state?.lastSince ?? null,
         lastSources: state?.lastSources ?? [],
+        lastSyncStatus: state?.lastSyncStatus ?? null,
         lastSuccessAt: state?.lastSuccessAt ?? null,
         lastSuccessDate: serviceLastSuccessDate(state) ?? null,
         lastUpserted: state?.lastUpserted ?? null,
@@ -1331,20 +1336,22 @@ function runServiceSyncOnce(paths: ServicePaths, options: ServiceRunOptions) {
     });
     const finalSuccessState =
       repairReport === undefined ? successState : serviceRepairState(successState, repairReport);
+    const syncFailed = result.value.status === "error";
     yield* writeServiceState(paths.statePath, finalSuccessState).pipe(
       Effect.mapError((cause) => new ServiceRunError({ cause })),
     );
     yield* writeScheduledServiceLog(
       console,
       options,
-      serviceRunLogLine(finalSuccessState, "success"),
+      serviceRunLogLine(finalSuccessState, syncFailed ? "failure" : "success"),
     );
     yield* writeServiceCheckIn(auth, {
       ...baseCheckIn,
       autoUpdate,
       ...serviceRunnerCheckIn(metadata, autoUpdate),
       ...serviceRepairCheckIn(repairReport),
-      status: "success",
+      ...(syncFailed ? { error: finalSuccessState.lastError } : {}),
+      status: syncFailed ? "failure" : "success",
     }).pipe(Effect.ignore);
 
     if (autoUpdated && metadata !== null && !options.scheduled) {
@@ -1363,7 +1370,9 @@ function runServiceSyncOnce(paths: ServicePaths, options: ServiceRunOptions) {
 
     if (!options.json && !options.scheduled) {
       yield* Effect.sync(() => {
-        console.log("Service run complete");
+        console.log(
+          syncFailed ? "Service run completed with source failures" : "Service run complete",
+        );
         console.log(`Log: ${paths.logPath}`);
       });
     }
@@ -1372,7 +1381,8 @@ function runServiceSyncOnce(paths: ServicePaths, options: ServiceRunOptions) {
       autoUpdated,
       logPath: paths.logPath,
       rows: result.value.rows,
-      status: "ok" as const,
+      sources: result.value.sourceResults,
+      status: result.value.status,
       upserted: result.value.upserted ?? 0,
     };
   });
@@ -1828,12 +1838,13 @@ function serviceRunSuccessState(
     lastAutoUpdated: input.autoUpdate.status === "success",
     lastCliVersion: input.version,
     lastDurationMs: input.durationMs,
-    lastError: undefined,
+    lastError: input.result.status === "error" ? "ccusage source collection failed" : undefined,
     lastRows: input.result.rows,
     lastSchedulerActive: input.schedulerActive,
     lastSince: input.since,
     lastSources: serviceSourcesForState(input.result),
-    lastSuccessAt: input.successAt,
+    lastSuccessAt: input.result.status === "error" ? currentState.lastSuccessAt : input.successAt,
+    lastSyncStatus: input.result.status,
     lastUpserted: input.result.upserted ?? 0,
     reloadRequired: input.reloadRequired,
     version: 1,
@@ -1869,22 +1880,31 @@ function serviceRunFailureState(
 
 function serviceSourcesForState(result: SyncResult): ServiceSourceState[] {
   return result.sourceResults.map((sourceResult) => {
-    const summary = sourceResult.summary;
-    if (summary === null) {
+    if (sourceResult.status === "failed") {
       return {
+        issue: sourceResult.issue,
         source: sourceResult.source,
-        status: "skipped" as const,
+        status: sourceResult.status,
       };
     }
 
+    if (sourceResult.status === "skipped") {
+      return {
+        source: sourceResult.source,
+        status: sourceResult.status,
+      };
+    }
+
+    const summary = sourceResult.summary;
     return {
       days: summary.days,
+      ...(sourceResult.status === "partial" ? { issue: sourceResult.issue } : {}),
       models: summary.models,
       rows: summary.rows,
       sessions: summary.sessions,
       source: sourceResult.source,
       spendUsd: summary.spendUsd,
-      status: "synced" as const,
+      status: sourceResult.status,
     };
   });
 }
@@ -1903,6 +1923,7 @@ function serviceRunLogLine(state: ServiceState, status: "failure" | "success") {
     schedulerActive: state.lastSchedulerActive,
     since: state.lastSince,
     sources: state.lastSources,
+    syncStatus: state.lastSyncStatus,
     status,
     timestamp: new Date().toISOString(),
     upserted: state.lastUpserted,
@@ -2225,6 +2246,7 @@ function serviceStateJson(state: ServiceState): Partial<ServiceState> {
       : { lastSchedulerActive: state.lastSchedulerActive }),
     ...(state.lastSince === undefined ? {} : { lastSince: state.lastSince }),
     ...(state.lastSources === undefined ? {} : { lastSources: state.lastSources }),
+    ...(state.lastSyncStatus === undefined ? {} : { lastSyncStatus: state.lastSyncStatus }),
     ...(state.lastSuccessAt === undefined ? {} : { lastSuccessAt: state.lastSuccessAt }),
     ...(state.lastUpserted === undefined ? {} : { lastUpserted: state.lastUpserted }),
     ...(state.reloadRequired === undefined ? {} : { reloadRequired: state.reloadRequired }),

--- a/apps/cli/src/commands/sync.test.ts
+++ b/apps/cli/src/commands/sync.test.ts
@@ -2,6 +2,7 @@ import { Cause, Effect, Layer, Option } from "effect";
 import type { AuthUser } from "@tokenmaxxing/api-contract";
 import { describe, expect, it } from "vitest";
 
+import { CcusageRunError } from "../ccusage/runner";
 import {
   ApiClientService,
   BrowserService,
@@ -23,9 +24,13 @@ import {
   renderSyncTable,
   resolveSyncAuth,
   sourceStatsForSync,
+  syncJsonPayload,
+  syncProgram,
+  syncStatusForSources,
   SyncAuthValidationError,
   SyncPushError,
   type SyncAuth,
+  type SyncSourceIssue,
   uploadUsageReports,
 } from "./sync";
 
@@ -53,6 +58,20 @@ const user: AuthUser = {
   login: "alex",
   name: null,
 };
+
+const invalidSessionIssue: SyncSourceIssue = {
+  code: "invalid_report",
+  message: "ccusage returned an invalid session report",
+  report: "session",
+};
+
+function ccusageFailure(
+  code: "command_failed" | "invalid_report",
+  report: "daily" | "session",
+  source: string,
+) {
+  return new CcusageRunError({ cause: new Error(code), code, report, source });
+}
 
 function makeTestLayer(options: TestLayerOptions) {
   let currentConfig = options.initialConfig;
@@ -228,10 +247,12 @@ describe("renderSyncTable", () => {
       [
         {
           source: "claude",
+          status: "synced",
           summary: { days: 17, models: 7, rows: 42, sessions: 17, spendUsd: 2_672 },
         },
         {
           source: "opencode",
+          status: "synced",
           summary: {
             days: 85,
             models: 9,
@@ -240,7 +261,7 @@ describe("renderSyncTable", () => {
             spendUsd: 1_699,
           },
         },
-        { source: "gemini", summary: null },
+        { reason: "no_data", source: "gemini", status: "skipped", summary: null },
       ],
       { env: { NO_COLOR: "" } },
     );
@@ -259,15 +280,46 @@ describe("renderSyncTable", () => {
       [
         {
           source: "claude",
+          status: "synced",
           summary: { days: 17, models: 7, rows: 42, sessions: 17, spendUsd: 2_672 },
         },
-        { source: "gemini", summary: null },
+        { reason: "no_data", source: "gemini", status: "skipped", summary: null },
       ],
       { env: {} },
     );
 
     expect(table).toContain("\x1b[32msynced");
     expect(table).toContain("\x1b[33mskipped");
+  });
+
+  it("distinguishes partial and failed sources", () => {
+    const table = renderSyncTable(
+      [
+        {
+          issue: invalidSessionIssue,
+          source: "codex",
+          status: "partial",
+          summary: { days: 3, models: 2, rows: 6, sessions: null, spendUsd: 12.34 },
+        },
+        {
+          issue: {
+            code: "command_failed",
+            message: "ccusage command failed",
+            report: "daily",
+          },
+          source: "gemini",
+          status: "failed",
+          summary: null,
+        },
+      ],
+      { env: { NO_COLOR: "" } },
+    );
+
+    expect(table.split("\n").map((line) => line.trim().split(/\s{2,}/))).toEqual([
+      ["Agent", "Status", "Days", "Sessions", "Models", "Spend"],
+      ["codex", "partial", "3", "-", "2", "$12.34"],
+      ["gemini", "failed", "-", "-", "-", "-"],
+    ]);
   });
 });
 
@@ -276,6 +328,7 @@ describe("renderSyncSourceResult", () => {
     expect(
       renderSyncSourceResult({
         source: "claude",
+        status: "synced",
         summary: { days: 17, models: 7, rows: 42, sessions: 54, spendUsd: 2_672 },
       }),
     ).toBe("claude synced - 17 days - 54 sessions - 7 models - $2,672");
@@ -285,15 +338,184 @@ describe("renderSyncSourceResult", () => {
     expect(
       renderSyncSourceResult({
         source: "opencode",
+        status: "synced",
         summary: { days: 85, models: 9, rows: 123, sessions: null, spendUsd: 1_699 },
       }),
     ).toBe("opencode synced - 85 days - sessions unknown - 9 models - $1,699");
   });
 
   it("renders skipped sources as a single status row", () => {
-    expect(renderSyncSourceResult({ source: "gemini", summary: null })).toBe(
-      "gemini skipped (no data)",
+    expect(
+      renderSyncSourceResult({
+        reason: "no_data",
+        source: "gemini",
+        status: "skipped",
+        summary: null,
+      }),
+    ).toBe("gemini skipped (no data)");
+  });
+
+  it("renders partial and failed sources with concise reasons", () => {
+    expect(
+      renderSyncSourceResult({
+        issue: invalidSessionIssue,
+        source: "codex",
+        status: "partial",
+        summary: { days: 3, models: 2, rows: 6, sessions: null, spendUsd: 12.34 },
+      }),
+    ).toBe(
+      "codex partially synced - 3 days - sessions unknown - 2 models - $12.34 - sessions unavailable: ccusage returned an invalid session report",
     );
+    expect(
+      renderSyncSourceResult({
+        issue: {
+          code: "command_failed",
+          message: "ccusage command failed",
+          report: "daily",
+        },
+        source: "gemini",
+        status: "failed",
+        summary: null,
+      }),
+    ).toBe("gemini failed - ccusage command failed");
+  });
+});
+
+describe("sync source outcomes", () => {
+  it("derives ok, partial, and error aggregate statuses", () => {
+    const skipped = {
+      reason: "no_data" as const,
+      source: "gemini",
+      status: "skipped" as const,
+      summary: null,
+    };
+    const failed = {
+      issue: {
+        code: "command_failed" as const,
+        message: "ccusage command failed",
+        report: "daily" as const,
+      },
+      source: "codex",
+      status: "failed" as const,
+      summary: null,
+    };
+
+    expect(syncStatusForSources([skipped], 0)).toBe("ok");
+    expect(syncStatusForSources([failed, skipped], 0)).toBe("error");
+    expect(syncStatusForSources([failed], 2)).toBe("partial");
+  });
+
+  it("adds stable source outcomes to JSON without removing the legacy sources map", () => {
+    const sourceResults = [
+      {
+        issue: {
+          code: "command_failed" as const,
+          message: "ccusage command failed",
+          report: "daily" as const,
+        },
+        source: "codex",
+        status: "failed" as const,
+        summary: null,
+      },
+    ];
+
+    expect(
+      syncJsonPayload({
+        dryRun: true,
+        rows: 0,
+        sourceResults,
+        sources: { codex: null },
+        status: "error",
+      }),
+    ).toEqual({
+      dryRun: true,
+      rows: 0,
+      sourceResults,
+      sources: { codex: null },
+      status: "error",
+    });
+  });
+
+  it("continues with successful sources after a daily report failure", async () => {
+    const { layer } = makeTestLayer({
+      initialConfig: {
+        apiUrl: "https://api.tokenmaxxing.example",
+        wwwUrl: "https://tokenmaxxing.example",
+      },
+      interactive: false,
+    });
+    const result = await Effect.runPromise(
+      syncProgram(
+        { dryRun: true, json: true, sources: "claude,codex" },
+        {
+          runDailyReport: (source) =>
+            source.source === "codex"
+              ? Effect.fail(ccusageFailure("command_failed", "daily", source.source))
+              : Effect.succeed({ daily: [{ date: "2026-07-22", totalTokens: 10 }] }),
+          runSessionReport: () => Effect.succeed({ sessions: [] }),
+        },
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(result.status).toBe("partial");
+    expect(result.rows).toBe(1);
+    expect(result.sourceResults.map(({ source, status }) => ({ source, status }))).toEqual([
+      { source: "claude", status: "synced" },
+      { source: "codex", status: "failed" },
+    ]);
+  });
+
+  it("keeps daily rows when the session report fails", async () => {
+    const { layer } = makeTestLayer({
+      initialConfig: {
+        apiUrl: "https://api.tokenmaxxing.example",
+        wwwUrl: "https://tokenmaxxing.example",
+      },
+      interactive: false,
+    });
+    const result = await Effect.runPromise(
+      syncProgram(
+        { dryRun: true, json: true, sources: "codex" },
+        {
+          runDailyReport: () =>
+            Effect.succeed({ daily: [{ date: "2026-07-22", totalTokens: 10 }] }),
+          runSessionReport: (source) =>
+            Effect.fail(ccusageFailure("invalid_report", "session", source.source)),
+        },
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(result.status).toBe("partial");
+    expect(result.rows).toBe(1);
+    expect(result.sourceResults[0]).toMatchObject({
+      issue: { code: "invalid_report", report: "session" },
+      status: "partial",
+      summary: { sessions: null },
+    });
+  });
+
+  it("treats a valid empty daily report as no data", async () => {
+    const { layer } = makeTestLayer({
+      initialConfig: {
+        apiUrl: "https://api.tokenmaxxing.example",
+        wwwUrl: "https://tokenmaxxing.example",
+      },
+      interactive: false,
+    });
+    const result = await Effect.runPromise(
+      syncProgram(
+        { dryRun: true, json: true, sources: "codex" },
+        {
+          runDailyReport: () => Effect.succeed({ daily: [] }),
+          runSessionReport: () => Effect.die("session report should not run"),
+        },
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.sourceResults).toEqual([
+      { reason: "no_data", source: "codex", status: "skipped", summary: null },
+    ]);
   });
 });
 
@@ -303,19 +525,25 @@ describe("sourceStatsForSync", () => {
       sourceStatsForSync([
         {
           source: "claude",
+          status: "synced",
           summary: { days: 17, models: 7, rows: 42, sessions: 54, spendUsd: 2_672 },
         },
         {
           source: "codex",
+          status: "synced",
           summary: { days: 89, models: 4, rows: 123, sessions: null, spendUsd: 12_172 },
         },
-        { source: "gemini", summary: null },
+        { reason: "no_data", source: "gemini", status: "skipped", summary: null },
       ]),
     ).toEqual([{ sessionCount: 54, source: "claude" }]);
   });
 
   it("returns undefined when there is nothing useful to upload", () => {
-    expect(sourceStatsForSync([{ source: "gemini", summary: null }])).toBeUndefined();
+    expect(
+      sourceStatsForSync([
+        { reason: "no_data", source: "gemini", status: "skipped", summary: null },
+      ]),
+    ).toBeUndefined();
   });
 });
 

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -12,6 +12,9 @@ import type {
 import packageJson from "../../package.json";
 import { aggregateDays, summarize, type SourceSummary } from "../ccusage/aggregate";
 import {
+  type CcusageReportKind,
+  CcusageRunError,
+  type CcusageRunErrorCode,
   dailyCcusageCommand,
   runCcusageDailyReport,
   runCcusageSessionReport,
@@ -121,6 +124,11 @@ interface SyncProgramOptions extends SyncOptions {
   uploadPolicy?: UploadRetryPolicy | undefined;
 }
 
+interface SyncProgramRuntime {
+  runDailyReport?: typeof runCcusageDailyReport | undefined;
+  runSessionReport?: typeof runCcusageSessionReport | undefined;
+}
+
 interface ResolveSyncAuthOptions {
   json: boolean;
   showStoredLoginSpinner?: boolean | undefined;
@@ -138,10 +146,19 @@ interface SyncAuth {
 
 type SyncSourceSummary = SourceSummary & { sessions: number | null };
 
-interface SyncSourceResult {
-  source: string;
-  summary: SyncSourceSummary | null;
+interface SyncSourceIssue {
+  code: CcusageRunErrorCode;
+  message: string;
+  report: CcusageReportKind;
 }
+
+type SyncSourceResult =
+  | { source: string; status: "failed"; summary: null; issue: SyncSourceIssue }
+  | { source: string; status: "partial"; summary: SyncSourceSummary; issue: SyncSourceIssue }
+  | { source: string; status: "skipped"; summary: null; reason: "no_data" }
+  | { source: string; status: "synced"; summary: SyncSourceSummary };
+
+type SyncStatus = "error" | "ok" | "partial";
 
 interface SyncResult {
   dryRun: boolean;
@@ -149,7 +166,7 @@ interface SyncResult {
   rows: number;
   sourceResults: SyncSourceResult[];
   sources: Record<string, SyncSourceSummary | null>;
-  status: "ok";
+  status: SyncStatus;
   upserted?: number | undefined;
 }
 
@@ -201,7 +218,9 @@ function syncEffect(options: SyncOptions) {
       }
 
       if (shouldRenderInlineSync(options)) {
-        if (result.rows === 0) {
+        if (result.status === "error") {
+          yield* humanLog("error", "No usage synced; source collection failed", options);
+        } else if (result.rows === 0) {
           yield* humanLog("info", "Nothing to sync", options);
         } else if (result.dryRun) {
           yield* humanLog("success", "Dry run complete; nothing pushed", options);
@@ -213,7 +232,9 @@ function syncEffect(options: SyncOptions) {
           console.log("");
           console.log(renderSyncTable(result.sourceResults));
           console.log("");
-          if (result.rows === 0) {
+          if (result.status === "error") {
+            console.error("No usage synced; source collection failed");
+          } else if (result.rows === 0) {
             console.log("Nothing to sync");
           } else if (result.dryRun) {
             console.log("Dry run complete; nothing pushed");
@@ -230,8 +251,10 @@ function syncEffect(options: SyncOptions) {
   );
 }
 
-function syncProgram(options: SyncProgramOptions) {
+function syncProgram(options: SyncProgramOptions, runtime: SyncProgramRuntime = {}) {
   return Effect.gen(function* () {
+    const runDailyReport = runtime.runDailyReport ?? runCcusageDailyReport;
+    const runSessionReport = runtime.runSessionReport ?? runCcusageSessionReport;
     const requested = options.sources?.split(",") ?? DEFAULT_SOURCE_NAMES;
     const { invalid, sources } = resolveSources(requested);
     if (invalid.length > 0) {
@@ -249,47 +272,91 @@ function syncProgram(options: SyncProgramOptions) {
     const renderInlineResults = shouldRenderInlineSync(options);
     for (const source of sources) {
       const spinner = yield* humanSpinner(`Syncing ${source.source}`, options);
-      const dailyReport = yield* runCcusageDailyReport(source, { since: options.since }).pipe(
-        Effect.tapError(() => Effect.sync(() => spinner.error(`Failed syncing ${source.source}`))),
+      const dailyResult = yield* runDailyReport(source, { since: options.since }).pipe(
+        Effect.match({
+          onFailure: (error) => ({ error, _tag: "failure" as const }),
+          onSuccess: (report) => ({ report, _tag: "success" as const }),
+        }),
       );
-      if (Option.isNone(dailyReport) || dailyReport.value.daily.length === 0) {
-        const result = { source: source.source, summary: null };
+
+      if (dailyResult._tag === "failure") {
+        const result = {
+          issue: syncSourceIssue(dailyResult.error),
+          source: source.source,
+          status: "failed" as const,
+          summary: null,
+        };
+        sourceSummaries[source.source] = null;
+        sourceResults.push(result);
+        spinner.error(
+          renderInlineResults ? renderSyncSourceResult(result) : `Failed syncing ${source.source}`,
+        );
+        continue;
+      }
+
+      const dailyReport = dailyResult.report;
+      if (dailyReport.daily.length === 0) {
+        const result = {
+          reason: "no_data" as const,
+          source: source.source,
+          status: "skipped" as const,
+          summary: null,
+        };
         sourceSummaries[source.source] = result.summary;
         sourceResults.push(result);
         spinner.stop(renderInlineResults ? renderSyncSourceResult(result) : undefined);
         continue;
       }
 
-      const sourceRows = aggregateDays(source.source, dailyReport.value.daily);
+      const sourceRows = aggregateDays(source.source, dailyReport.daily);
       rawReports.push({
         command: dailyCcusageCommand(source, { since: options.since }),
-        payload: dailyReport.value,
+        payload: dailyReport,
         reportKind: "daily",
         source: source.source,
       });
 
-      const sessionReport = yield* runCcusageSessionReport(source, { since: options.since }).pipe(
-        Effect.tapError(() => Effect.sync(() => spinner.error(`Failed syncing ${source.source}`))),
+      const sessionResult = yield* runSessionReport(source, { since: options.since }).pipe(
+        Effect.match({
+          onFailure: (error) => ({ error, _tag: "failure" as const }),
+          onSuccess: (report) => ({ report, _tag: "success" as const }),
+        }),
       );
-      const sessionCount = Option.match(sessionReport, {
-        onNone: () => null,
-        onSome: (report) => report.sessions.length,
-      });
-      if (options.since === undefined && Option.isSome(sessionReport)) {
+      const sessionCount =
+        sessionResult._tag === "success" ? sessionResult.report.sessions.length : null;
+      if (options.since === undefined && sessionResult._tag === "success") {
         rawReports.push({
           command: sessionCcusageCommand(source),
-          payload: sessionReport.value,
+          payload: sessionResult.report,
           reportKind: "session",
           source: source.source,
         });
       }
       const summary = { ...summarize(sourceRows), sessions: sessionCount };
-      const result = { source: source.source, summary };
+      const result: SyncSourceResult =
+        sessionResult._tag === "failure"
+          ? {
+              issue: syncSourceIssue(sessionResult.error),
+              source: source.source,
+              status: "partial",
+              summary,
+            }
+          : { source: source.source, status: "synced", summary };
       sourceSummaries[source.source] = summary;
       sourceResults.push(result);
       rows.push(...sourceRows);
-      spinner.stop(renderInlineResults ? renderSyncSourceResult(result) : undefined);
+      if (result.status === "partial") {
+        spinner.error(
+          renderInlineResults
+            ? renderSyncSourceResult(result)
+            : `Partially synced ${source.source}`,
+        );
+      } else {
+        spinner.stop(renderInlineResults ? renderSyncSourceResult(result) : undefined);
+      }
     }
+
+    const status = syncStatusForSources(sourceResults, rows.length);
 
     if (options.dryRun || rows.length === 0) {
       return {
@@ -297,7 +364,7 @@ function syncProgram(options: SyncProgramOptions) {
         rows: rows.length,
         sourceResults,
         sources: sourceSummaries,
-        status: "ok" as const,
+        status,
       };
     }
 
@@ -314,7 +381,7 @@ function syncProgram(options: SyncProgramOptions) {
         rows: rows.length,
         sourceResults,
         sources: sourceSummaries,
-        status: "ok" as const,
+        status,
       };
     }
 
@@ -333,7 +400,7 @@ function syncProgram(options: SyncProgramOptions) {
       rows: rows.length,
       sourceResults,
       sources: sourceSummaries,
-      status: "ok" as const,
+      status,
       upserted,
     };
   });
@@ -426,6 +493,7 @@ function syncJsonPayload(result: SyncResult) {
     return {
       dryRun: result.dryRun,
       rows: result.rows,
+      sourceResults: result.sourceResults,
       sources: result.sources,
       status: result.status,
     };
@@ -433,6 +501,7 @@ function syncJsonPayload(result: SyncResult) {
 
   return {
     rows: result.rows,
+    sourceResults: result.sourceResults,
     sources: result.sources,
     status: result.status,
     upserted: result.upserted ?? 0,
@@ -449,6 +518,32 @@ function sourceStatsForSync(
   );
 
   return stats.length === 0 ? undefined : stats;
+}
+
+function syncSourceIssue(error: CcusageRunError): SyncSourceIssue {
+  const message =
+    error.code === "command_not_found"
+      ? "ccusage command not found"
+      : error.code === "command_timed_out"
+        ? "ccusage command timed out"
+        : error.code === "command_failed"
+          ? "ccusage command failed"
+          : error.code === "invalid_json"
+            ? "ccusage returned invalid JSON"
+            : `ccusage returned an invalid ${error.report} report`;
+
+  return { code: error.code, message, report: error.report };
+}
+
+function syncStatusForSources(results: readonly SyncSourceResult[], rows: number): SyncStatus {
+  const hasIssues = results.some(
+    (result) => result.status === "failed" || result.status === "partial",
+  );
+  if (!hasIssues) {
+    return "ok";
+  }
+
+  return rows > 0 ? "partial" : "error";
 }
 
 function openProfileIfAvailable(
@@ -484,7 +579,11 @@ function shouldRenderInlineSync(options: { json?: boolean; silent?: boolean }): 
 }
 
 function renderSyncSourceResult(result: SyncSourceResult): string {
-  if (result.summary === null) {
+  if (result.status === "failed") {
+    return `${result.source} failed - ${result.issue.message}`;
+  }
+
+  if (result.status === "skipped") {
     return `${result.source} skipped (no data)`;
   }
 
@@ -493,13 +592,18 @@ function renderSyncSourceResult(result: SyncSourceResult): string {
       ? "sessions unknown"
       : formatCount(result.summary.sessions, "session");
 
-  return [
-    `${result.source} synced`,
+  const row = [
+    `${result.source} ${result.status === "partial" ? "partially synced" : "synced"}`,
     formatCount(result.summary.days, "day"),
     sessions,
     formatCount(result.summary.models, "model"),
     formatSyncUsd(result.summary.spendUsd),
-  ].join(" - ");
+  ];
+  if (result.status === "partial") {
+    row.push(`sessions unavailable: ${result.issue.message}`);
+  }
+
+  return row.join(" - ");
 }
 
 function renderSyncTable(
@@ -516,10 +620,13 @@ function renderSyncTable(
     { align: "right", value: "Spend" },
   ];
   const rows = results.map((result): readonly TableCell[] => {
-    if (result.summary === null) {
+    if (result.status === "failed" || result.status === "skipped") {
       return [
         { value: result.source },
-        { style: styles.skipped, value: "skipped" },
+        {
+          style: result.status === "failed" ? styles.failed : styles.skipped,
+          value: result.status,
+        },
         { align: "right", style: styles.muted, value: "-" },
         { align: "right", style: styles.muted, value: "-" },
         { align: "right", style: styles.muted, value: "-" },
@@ -529,7 +636,10 @@ function renderSyncTable(
 
     return [
       { value: result.source },
-      { style: styles.synced, value: "synced" },
+      {
+        style: result.status === "partial" ? styles.partial : styles.synced,
+        value: result.status,
+      },
       { align: "right", value: formatInteger(result.summary.days) },
       {
         align: "right",
@@ -583,7 +693,9 @@ function visibleLength(value: string): number {
 }
 
 function makeStyles(options: FormatOptions = {}): {
+  failed: Style;
   muted: Style;
+  partial: Style;
   skipped: Style;
   synced: Style;
 } {
@@ -591,7 +703,9 @@ function makeStyles(options: FormatOptions = {}): {
   const colors = !Object.prototype.hasOwnProperty.call(env, "NO_COLOR");
 
   return {
+    failed: (value) => (colors ? `\x1b[31m${value}\x1b[0m` : value),
     muted: (value) => (colors ? `\x1b[2m${value}\x1b[0m` : value),
+    partial: (value) => (colors ? `\x1b[33m${value}\x1b[0m` : value),
     skipped: (value) => (colors ? `\x1b[33m${value}\x1b[0m` : value),
     synced: (value) => (colors ? `\x1b[32m${value}\x1b[0m` : value),
   };
@@ -684,6 +798,8 @@ export {
   renderSyncTable,
   resolveSyncAuth,
   sourceStatsForSync,
+  syncSourceIssue,
+  syncStatusForSources,
   syncCommand,
   syncEffect,
   syncJsonPayload,
@@ -699,6 +815,10 @@ export type {
   SyncAuth,
   SyncOptions,
   SyncResult,
+  SyncProgramRuntime,
+  SyncSourceIssue,
+  SyncSourceResult,
   SyncSourceSummary,
+  SyncStatus,
   UploadRetryPolicy,
 };


### PR DESCRIPTION
## Summary

- preserve typed ccusage launch, timeout, JSON, and schema failures until the sync layer classifies them
- isolate failures per source so healthy agents continue syncing and daily rows survive a session-report failure
- expose stable `synced`, `skipped`, `partial`, and `failed` source outcomes in human output, JSON, and service diagnostics while retaining the legacy `sources` map

## Behavior

- a daily report failure marks that source as failed
- a session report failure marks that source as partial and retains its daily usage rows
- a valid empty daily report remains a no-data skip
- aggregate sync status is `ok`, `partial`, or `error`

## Attribution

Follow-up to #44 and to the original report and investigation in #27 by @Pimpmuckl. The implementation commit includes Jonathan as a co-author.

## Validation

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Closes #45

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/tokenmaxxing/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787337951&installation_model_id=428386&pr_number=49&repository=851-labs%2Ftokenmaxxing&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Ftokenmaxxing%2Fpull%2F49&signature=9c5a7ca5de54c29871d80b2b44041bf90f45be04a729ae9745060f7f670d2064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->