### PR TITLE
feat(cli): sync Pi usage via ccusage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tokenmaxxing
 
 The social leaderboard for LLM token usage. Sync your local agent usage
-(Claude Code, Codex, OpenCode, Gemini CLI, Copilot CLI), climb the board at
+(Claude Code, Codex, OpenCode, Gemini CLI, Copilot CLI, Pi), climb the board at
 [tokenmaxxing.sh](https://tokenmaxxing.sh).
 
 Built on [ccusage](https://github.com/ryoppippi/ccusage) for local usage

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -2,7 +2,7 @@
 
 CLI for [tokenmaxxing](https://tokenmaxxing.sh) — the social leaderboard
 for LLM token usage. Parses your local agent usage (Claude Code, Codex,
-OpenCode, Gemini CLI, Copilot CLI) via
+OpenCode, Gemini CLI, Copilot CLI, Pi) via
 [ccusage](https://github.com/ryoppippi/ccusage) and pushes daily aggregates
 to your public profile.
 

--- a/apps/cli/src/ccusage/aggregate.test.ts
+++ b/apps/cli/src/ccusage/aggregate.test.ts
@@ -124,6 +124,32 @@ const opencodeFixture = {
   ],
 };
 
+/** Mirrors the ccusage v20 Pi agent-summary daily shape. */
+const piFixture = {
+  daily: [
+    {
+      date: "2026-07-01",
+      inputTokens: 1_200,
+      outputTokens: 300,
+      cacheCreationTokens: 100,
+      cacheReadTokens: 2_400,
+      totalTokens: 4_000,
+      totalCost: 0.42,
+      modelsUsed: ["[pi] claude-sonnet-4"],
+      modelBreakdowns: [
+        {
+          modelName: "[pi] claude-sonnet-4",
+          inputTokens: 1_200,
+          outputTokens: 300,
+          cacheCreationTokens: 100,
+          cacheReadTokens: 2_400,
+          cost: 0.42,
+        },
+      ],
+    },
+  ],
+};
+
 describe("decodeDailyReport", () => {
   it("parses the verified v20 focused-command shape", async () => {
     const report = await Effect.runPromise(decodeDailyReport(claudeFixture));
@@ -240,6 +266,25 @@ describe("aggregateDays", () => {
     expect(rows).toHaveLength(2);
     expect(rows[0]).toMatchObject({ costUsd: 68.88, model: "gpt-5.3-codex" });
     expect(rows[1]).toMatchObject({ costUsd: 1.0, model: "unknown" });
+  });
+
+  it("decodes and aggregates Pi agent-summary reports", async () => {
+    const report = await Effect.runPromise(decodeDailyReport(piFixture));
+    const rows = aggregateDays("pi", report.daily);
+
+    expect(rows).toEqual([
+      {
+        cacheCreationTokens: 100,
+        cacheReadTokens: 2_400,
+        costUsd: 0.42,
+        date: "2026-07-01",
+        inputTokens: 1_200,
+        model: "[pi] claude-sonnet-4",
+        outputTokens: 300,
+        source: "pi",
+        totalTokens: 4_000,
+      },
+    ]);
   });
 
   it("distributes day cost over token weight when breakdowns lack per-model cost", () => {

--- a/apps/cli/src/ccusage/runner.test.ts
+++ b/apps/cli/src/ccusage/runner.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./runner";
 
 const codex = { source: "codex", subcommand: "codex" };
+const pi = { source: "pi", subcommand: "pi" };
 
 async function ccusageErrorFor<A>(effect: Effect.Effect<A, CcusageRunError>) {
   const exit = await Effect.runPromiseExit(effect);
@@ -42,6 +43,26 @@ describe("ccusage commands", () => {
     expect(sessionCcusageCommand(codex)).toEqual([
       "ccusage@^20.0.17",
       "codex",
+      "session",
+      "--json",
+      "--mode",
+      "calculate",
+    ]);
+  });
+
+  it("builds focused Pi daily and session commands", () => {
+    expect(dailyCcusageCommand(pi)).toEqual([
+      "ccusage@^20.0.17",
+      "pi",
+      "daily",
+      "--json",
+      "--breakdown",
+      "--mode",
+      "calculate",
+    ]);
+    expect(sessionCcusageCommand(pi)).toEqual([
+      "ccusage@^20.0.17",
+      "pi",
       "session",
       "--json",
       "--mode",

--- a/apps/cli/src/ccusage/sources.test.ts
+++ b/apps/cli/src/ccusage/sources.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SOURCE_NAMES, resolveSources } from "./sources";
+
+describe("resolveSources", () => {
+  it("accepts every default source", () => {
+    const { invalid, sources } = resolveSources(DEFAULT_SOURCE_NAMES);
+
+    expect(invalid).toEqual([]);
+    expect(sources.map((entry) => entry.source)).toEqual(DEFAULT_SOURCE_NAMES);
+  });
+
+  it("resolves Pi to the focused ccusage subcommand", () => {
+    expect(resolveSources(["pi"])).toEqual({
+      invalid: [],
+      sources: [{ source: "pi", subcommand: "pi" }],
+    });
+  });
+
+  it("rejects unknown sources", () => {
+    expect(resolveSources(["bogus"]).invalid).toEqual(["bogus"]);
+  });
+});

--- a/apps/cli/src/ccusage/sources.ts
+++ b/apps/cli/src/ccusage/sources.ts
@@ -18,6 +18,7 @@ const CCUSAGE_SOURCES: readonly CcusageSource[] = [
   { source: "opencode", subcommand: "opencode" },
   { source: "gemini", subcommand: "gemini" },
   { source: "copilot", subcommand: "copilot" },
+  { source: "pi", subcommand: "pi" },
 ];
 
 const DEFAULT_SOURCE_NAMES = CCUSAGE_SOURCES.map((entry) => entry.source);


### PR DESCRIPTION
## Summary

- register Pi as a focused ccusage source and include it in default syncs
- verify Pi source resolution, daily/session command construction, and representative report aggregation
- document Pi alongside the other supported coding-agent harnesses

This is a focused replacement for #26. It intentionally leaves out the unrelated timezone-test change, and credits Jace as a co-author of the implementation.

## Testing

- `bun test apps/cli/src/ccusage/sources.test.ts apps/cli/src/ccusage/runner.test.ts apps/cli/src/ccusage/aggregate.test.ts`
- `bunx ccusage@^20.0.17 pi daily --json --breakdown --mode calculate`
- `bunx ccusage@^20.0.17 pi session --json --mode calculate`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/tokenmaxxing/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787338557&installation_model_id=428386&pr_number=50&repository=851-labs%2Ftokenmaxxing&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Ftokenmaxxing%2Fpull%2F50&signature=ad0fb79ce8cdea76c25a99787c9c218ec4d7d2452dfdfb1ad247badf355398cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->