### PR TITLE
test(cli): stabilize scheduled sync tests across timezones

### DIFF
--- a/apps/cli/src/commands/service.test.ts
+++ b/apps/cli/src/commands/service.test.ts
@@ -1336,11 +1336,14 @@ describe("service auto-update reports", () => {
 });
 
 describe("serviceScheduledSyncSince", () => {
+  const localDateTime = (year: number, month: number, day: number, hour = 12, minute = 0): Date =>
+    new Date(year, month - 1, day, hour, minute);
+
   it("uses the previous successful local date for scheduled syncs", () => {
     expect(
       serviceScheduledSyncSince(
-        { lastSuccessAt: "2026-06-16T23:30:00.000Z", version: 1 },
-        new Date("2026-06-17T00:05:00.000Z"),
+        { lastSuccessAt: localDateTime(2026, 6, 16, 23, 30).toISOString(), version: 1 },
+        localDateTime(2026, 6, 17, 0, 5),
         true,
       ),
     ).toBe("2026-06-16");
@@ -1350,27 +1353,27 @@ describe("serviceScheduledSyncSince", () => {
     expect(
       serviceScheduledSyncSince(
         { lastSuccessDate: "2026-06-15", version: 1 },
-        new Date("2026-06-17T12:00:00.000Z"),
+        localDateTime(2026, 6, 17),
         true,
       ),
     ).toBe("2026-06-15");
   });
 
   it("falls back to yesterday when no reliable marker exists", () => {
-    expect(
-      serviceScheduledSyncSince({ version: 1 }, new Date("2026-06-17T12:00:00.000Z"), true),
-    ).toBe("2026-06-16");
+    expect(serviceScheduledSyncSince({ version: 1 }, localDateTime(2026, 6, 17), true)).toBe(
+      "2026-06-16",
+    );
     expect(
       serviceScheduledSyncSince(
         { lastSuccessAt: "not-a-date", version: 1 },
-        new Date("2026-06-17T12:00:00.000Z"),
+        localDateTime(2026, 6, 17),
         true,
       ),
     ).toBe("2026-06-16");
     expect(
       serviceScheduledSyncSince(
-        { lastSuccessAt: "2026-06-18T00:00:00.000Z", version: 1 },
-        new Date("2026-06-17T12:00:00.000Z"),
+        { lastSuccessAt: localDateTime(2026, 6, 18).toISOString(), version: 1 },
+        localDateTime(2026, 6, 17),
         true,
       ),
     ).toBe("2026-06-16");
@@ -1379,8 +1382,8 @@ describe("serviceScheduledSyncSince", () => {
   it("does not set since for manual service runs", () => {
     expect(
       serviceScheduledSyncSince(
-        { lastSuccessAt: "2026-06-16T23:30:00.000Z", version: 1 },
-        new Date("2026-06-17T00:05:00.000Z"),
+        { lastSuccessAt: localDateTime(2026, 6, 16, 23, 30).toISOString(), version: 1 },
+        localDateTime(2026, 6, 17, 0, 5),
         false,
       ),
     ).toBeUndefined();


### PR DESCRIPTION
## Summary

- construct scheduled-sync test timestamps in local wall-clock time
- cover every timestamp fixture in the test block without changing production behavior
- keep ccusage date bucketing local to the device, as intended

PR #26 identified the portability problem, but its proposed production injection fixed only one assertion and left the fallback test timezone-dependent in UTC+12 through UTC+14. This focused follow-up keeps the runtime implementation unchanged and credits Jace as a co-author.

## Testing

The focused `serviceScheduledSyncSince` tests pass under:

- `TZ=UTC`
- `TZ=America/Los_Angeles`
- `TZ=Europe/Bucharest`
- `TZ=Pacific/Kiritimati`
- `TZ=Pacific/Pago_Pago`

Full repository gates:

- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/tokenmaxxing/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787338894&installation_model_id=428386&pr_number=51&repository=851-labs%2Ftokenmaxxing&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Ftokenmaxxing%2Fpull%2F51&signature=417c6a943e5ed763cdbf8b2cc03e63a236dc215afbd4eb449588a6f3a9bdf78f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->