### PR TITLE
fix(usage): upload aggregate session stats only

### DIFF
--- a/apps/api/src/http/layer.ts
+++ b/apps/api/src/http/layer.ts
@@ -135,7 +135,12 @@ const usageHandlers = HttpApiBuilder.group(TokenmaxxingApi, "usage", (handlers) 
       Effect.gen(function* () {
         const identity = yield* CurrentCliIdentity;
         const usage = yield* UsageService;
-        return yield* usage.ingestRaw(identity, payload.device, payload.reports);
+        return yield* usage.ingestRaw(
+          identity,
+          payload.device,
+          payload.reports,
+          payload.sourceStats,
+        );
       }),
     )
     .handle("sync", ({ payload }) =>

--- a/apps/api/src/usage/ccusage.test.ts
+++ b/apps/api/src/usage/ccusage.test.ts
@@ -40,6 +40,7 @@ describe("parseRawUsageReports", () => {
 
     const result = await Effect.runPromise(parseRawUsageReports(reports));
 
+    expect(result.persistableReports).toEqual(reports);
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0]).toMatchObject({
       cacheReadTokens: 23_162_112,
@@ -48,5 +49,65 @@ describe("parseRawUsageReports", () => {
       totalTokens: 25_040_594,
     });
     expect(result.rows[0]?.costUsd).toBeCloseTo(58.78);
+  });
+
+  it("normalizes daily reports and never marks legacy session reports for persistence", async () => {
+    const result = await Effect.runPromise(
+      parseRawUsageReports([
+        {
+          command: ["ccusage@^20", "claude", "daily", "--json"],
+          payload: {
+            daily: [
+              {
+                date: "2026-07-22",
+                projectPath: "/Users/alex/secret-client",
+                totalTokens: 100,
+              },
+            ],
+          },
+          reportKind: "daily",
+          source: "claude",
+        },
+        {
+          command: ["ccusage@^20", "claude", "session", "--json"],
+          payload: {
+            sessions: [
+              {
+                projectPath: "/Users/alex/secret-client",
+                sessionId: "-Users-alex-secret-client",
+              },
+            ],
+          },
+          reportKind: "session",
+          source: "claude",
+        },
+      ]),
+    );
+
+    expect(result.persistableReports).toEqual([
+      {
+        command: ["ccusage@^20", "claude", "daily", "--json"],
+        payload: { daily: [{ date: "2026-07-22", totalTokens: 100 }] },
+        reportKind: "daily",
+        source: "claude",
+      },
+    ]);
+    expect(result.sourceStats).toEqual([{ sessionCount: 1, source: "claude" }]);
+    expect(JSON.stringify(result.persistableReports)).not.toContain("secret-client");
+  });
+
+  it("drops invalid daily reports instead of persisting unknown payloads", async () => {
+    const result = await Effect.runPromise(
+      parseRawUsageReports([
+        {
+          command: ["ccusage@^20", "codex", "daily", "--json"],
+          payload: { projectPath: "/Users/alex/secret-client" },
+          reportKind: "daily",
+          source: "codex",
+        },
+      ]),
+    );
+
+    expect(result).toEqual({ persistableReports: [], rows: [], sourceStats: [] });
   });
 });

--- a/apps/api/src/usage/ccusage.ts
+++ b/apps/api/src/usage/ccusage.ts
@@ -5,7 +5,7 @@ import type {
 } from "@tokenmaxxing/api-contract";
 import { Effect, Option, Schema } from "effect";
 
-const PARSER_VERSION = "ccusage-v20-raw-2";
+const PARSER_VERSION = "ccusage-v20-raw-3";
 
 const CcusageModelBreakdown = Schema.Struct({
   cacheCreationTokens: Schema.optional(Schema.Number),
@@ -56,14 +56,20 @@ const decodeDailyReport = Schema.decodeUnknownEffect(CcusageDailyReport);
 const decodeSessionReport = Schema.decodeUnknownEffect(CcusageSessionReport);
 
 interface ParsedRawUsageReports {
+  persistableReports: PersistableDailyReport[];
   rows: UsageDayInput[];
   sourceStats: SourceUsageStatsInput[];
 }
+
+type PersistableDailyReport = Omit<RawUsageReportInput, "reportKind"> & {
+  reportKind: "daily";
+};
 
 function parseRawUsageReports(
   reports: readonly RawUsageReportInput[],
 ): Effect.Effect<ParsedRawUsageReports> {
   return Effect.gen(function* () {
+    const persistableReports: PersistableDailyReport[] = [];
     const rows: UsageDayInput[] = [];
     const sourceStats: SourceUsageStatsInput[] = [];
 
@@ -71,6 +77,12 @@ function parseRawUsageReports(
       if (report.reportKind === "daily") {
         const decoded = yield* decodeDailyReport(report.payload).pipe(Effect.option);
         if (Option.isSome(decoded)) {
+          persistableReports.push({
+            command: report.command,
+            payload: decoded.value,
+            reportKind: "daily",
+            source: report.source,
+          });
           rows.push(...aggregateDays(report.source, decoded.value.daily));
         }
       } else {
@@ -84,7 +96,7 @@ function parseRawUsageReports(
       }
     }
 
-    return { rows, sourceStats };
+    return { persistableReports, rows, sourceStats };
   });
 }
 
@@ -200,3 +212,5 @@ function collectModelEntries(day: CcusageDay): ModelTotals[] {
 }
 
 export { parseRawUsageReports, PARSER_VERSION };
+
+export type { PersistableDailyReport };

--- a/apps/api/src/usage/service.test.ts
+++ b/apps/api/src/usage/service.test.ts
@@ -61,7 +61,9 @@ const rawReports: RawUsageReportInput[] = [
   },
   {
     command: ["ccusage@^20", "codex", "session", "--json", "--mode", "calculate"],
-    payload: { sessions: [{ sessionId: "a" }, { sessionId: "b" }] },
+    payload: {
+      sessions: [{ projectPath: "/Users/alex/secret-client", sessionId: "a" }, { sessionId: "b" }],
+    },
     reportKind: "session",
     source: "codex",
   },
@@ -95,6 +97,7 @@ interface TestUsageService {
     },
     syncDevice: typeof device,
     reports: readonly RawUsageReportInput[],
+    syncSourceStats?: readonly (typeof sourceStats)[number][],
   ): Effect.Effect<SyncResult, DeviceMissing>;
 }
 
@@ -301,7 +304,7 @@ describe("UsageService.syncBatch", () => {
 });
 
 describe("UsageService.ingestRaw", () => {
-  it("stores raw reports, derives structured rows, and touches the device", async () => {
+  it("stores normalized daily reports and derives legacy session counts without persisting them", async () => {
     const { repository, touchDevice, upsertChunk, upsertRawReports, upsertSourceStats } =
       makeRepository();
     const service = await makeService(repository);
@@ -315,7 +318,7 @@ describe("UsageService.ingestRaw", () => {
     expect(upsertRawReports).toHaveBeenCalledWith(
       "user_123",
       "device_123",
-      expect.arrayContaining([
+      [
         expect.objectContaining<Partial<StoredRawUsageReport>>({
           ccusageCommand: "ccusage@^20 codex daily --json --breakdown --mode calculate",
           objectKey: expect.stringMatching(
@@ -323,23 +326,14 @@ describe("UsageService.ingestRaw", () => {
           ) as unknown as string,
           payloadBytes: JSON.stringify(rawReports[0]!.payload).length,
           payloadJson: JSON.stringify(rawReports[0]!.payload),
-          parserVersion: "ccusage-v20-raw-2",
+          parserVersion: "ccusage-v20-raw-3",
           reportKind: "daily",
           source: "codex",
         }),
-        expect.objectContaining<Partial<StoredRawUsageReport>>({
-          ccusageCommand: "ccusage@^20 codex session --json --mode calculate",
-          objectKey: expect.stringMatching(
-            /^users\/user_123\/devices\/device_123\/ccusage\/codex\/session\/[a-f0-9]+\.json$/,
-          ) as unknown as string,
-          payloadBytes: JSON.stringify(rawReports[1]!.payload).length,
-          payloadJson: JSON.stringify(rawReports[1]!.payload),
-          reportKind: "session",
-          source: "codex",
-        }),
-      ]),
+      ],
       expect.any(Date),
     );
+    expect(JSON.stringify(upsertRawReports.mock.calls)).not.toContain("secret-client");
     expect(upsertChunk).toHaveBeenCalledWith(
       "user_123",
       "device_123",
@@ -355,6 +349,34 @@ describe("UsageService.ingestRaw", () => {
     expect(touchDevice).toHaveBeenCalledWith("device_123", device, expect.any(Date));
     expect(upsertRawReports.mock.invocationCallOrder[0]).toBeLessThan(
       upsertChunk.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("prefers explicit source stats and deterministically keeps the last duplicate", async () => {
+    const { repository, upsertSourceStats } = makeRepository();
+    const service = await makeService(repository);
+
+    await Effect.runPromise(
+      service.ingestRaw(
+        { deviceId: "device_123", tokenId: "token_123", user },
+        device,
+        rawReports,
+        [
+          { sessionCount: 7, source: "codex" },
+          { sessionCount: 9, source: "codex" },
+          { sessionCount: 3, source: "claude" },
+        ],
+      ),
+    );
+
+    expect(upsertSourceStats).toHaveBeenCalledWith(
+      "user_123",
+      "device_123",
+      [
+        { sessionCount: 9, source: "codex" },
+        { sessionCount: 3, source: "claude" },
+      ],
+      expect.any(Date),
     );
   });
 

--- a/apps/api/src/usage/service.ts
+++ b/apps/api/src/usage/service.ts
@@ -17,14 +17,15 @@ import type {
 
 import { sha256Hex } from "../auth/crypto";
 import type { DatabaseError } from "../database";
-import { parseRawUsageReports, PARSER_VERSION } from "./ccusage";
+import { parseRawUsageReports, PARSER_VERSION, type PersistableDailyReport } from "./ccusage";
 import { normalizeUsageDays } from "./models";
 import type { RawUsageStorageError } from "./raw-store";
 
 /**
- * Usage ingestion: raw reports are stored first, then current structured rows
- * are derived and upserted idempotently by (deviceId, date, source, model).
- * The deviceId always comes from the presenting token — payloads cannot write
+ * Usage ingestion: normalized daily reports are stored first, then current
+ * structured rows and aggregate source stats are upserted idempotently.
+ * Legacy session reports are counted in memory and never persisted. The
+ * deviceId always comes from the presenting token, so payloads cannot write
  * into another device's history.
  */
 
@@ -43,7 +44,7 @@ interface StoredRawUsageReport {
   payloadHash: string;
   payloadJson: string;
   processedAt: Date;
-  reportKind: "daily" | "session";
+  reportKind: "daily";
   source: string;
 }
 
@@ -57,6 +58,7 @@ interface UsageServiceShape {
     identity: typeof CliIdentity.Type,
     device: UsageDevice,
     reports: readonly RawUsageReportInput[],
+    sourceStats?: readonly SourceUsageStatsInput[],
   ): Effect.Effect<SyncResult, DeviceMissing, any>;
   syncBatch(
     identity: typeof CliIdentity.Type,
@@ -159,23 +161,33 @@ const makeUsageService = Effect.fn("makeUsageService")(function* () {
         checkedInAt: checkedInAt.toISOString(),
       };
     }),
-    ingestRaw: Effect.fn("UsageService.ingestRaw")(function* (identity, device, reports) {
+    ingestRaw: Effect.fn("UsageService.ingestRaw")(function* (
+      identity,
+      device,
+      reports,
+      sourceStats = [],
+    ) {
       const deviceId = yield* requireDeviceId(identity);
       const syncedAt = new Date();
-      const rawReports = yield* prepareRawReports(identity.user.id, deviceId, reports, syncedAt);
+      const parsed = yield* parseRawUsageReports(reports);
+      const rawReports = yield* prepareRawReports(
+        identity.user.id,
+        deviceId,
+        parsed.persistableReports,
+        syncedAt,
+      );
 
       yield* repository
         .upsertRawReports(identity.user.id, deviceId, rawReports, syncedAt)
         .pipe(Effect.orDie);
 
-      const parsed = yield* parseRawUsageReports(reports);
       const upserted = yield* writeStructuredUsage(
         repository,
         identity.user.id,
         deviceId,
         device,
         parsed.rows,
-        parsed.sourceStats,
+        mergeSourceStats(parsed.sourceStats, sourceStats),
         syncedAt,
       );
 
@@ -229,7 +241,7 @@ function requireDeviceId(identity: typeof CliIdentity.Type): Effect.Effect<strin
 function prepareRawReports(
   userId: string,
   deviceId: string,
-  reports: readonly RawUsageReportInput[],
+  reports: readonly PersistableDailyReport[],
   processedAt: Date,
 ): Effect.Effect<StoredRawUsageReport[]> {
   return Effect.forEach(reports, (report) =>
@@ -265,7 +277,7 @@ function prepareRawReports(
 function rawReportObjectKey(input: {
   deviceId: string;
   payloadHash: string;
-  reportKind: "daily" | "session";
+  reportKind: "daily";
   source: string;
   userId: string;
 }): string {
@@ -283,6 +295,21 @@ function rawReportObjectKey(input: {
 
 function encodeKeyPart(value: string): string {
   return encodeURIComponent(value);
+}
+
+function mergeSourceStats(
+  legacyStats: readonly SourceUsageStatsInput[],
+  explicitStats: readonly SourceUsageStatsInput[],
+): SourceUsageStatsInput[] {
+  const merged = new Map<string, SourceUsageStatsInput>();
+  for (const stat of legacyStats) {
+    merged.set(stat.source, stat);
+  }
+  for (const stat of explicitStats) {
+    merged.set(stat.source, stat);
+  }
+
+  return [...merged.values()];
 }
 
 function writeStructuredUsage(

--- a/apps/cli/src/commands/sync.test.ts
+++ b/apps/cli/src/commands/sync.test.ts
@@ -204,10 +204,13 @@ function makeConsoleLayer() {
 interface TestUsageIngestRequest {
   payload: {
     device: {
+      arch?: string;
       name: string;
       platform: NodeJS.Platform;
+      version?: string;
     };
     reports: unknown[];
+    sourceStats?: { sessionCount: number; source: string }[];
   };
 }
 
@@ -465,6 +468,56 @@ describe("sync source outcomes", () => {
     ]);
   });
 
+  it("uploads daily reports plus aggregate session counts without session payloads", async () => {
+    const { layer } = makeTestLayer({
+      initialConfig: {
+        apiUrl: "https://api.tokenmaxxing.example",
+        wwwUrl: "https://tokenmaxxing.example",
+      },
+      interactive: false,
+    });
+    let uploadPayload: TestUsageIngestRequest["payload"] | undefined;
+    const auth = makeUploadAuth((request) =>
+      Effect.sync(() => {
+        uploadPayload = request.payload;
+        return { received: 1, syncedAt: "2026-07-22T00:00:00.000Z", upserted: 1 };
+      }),
+    );
+
+    const result = await Effect.runPromise(
+      syncProgram(
+        { auth, dryRun: false, json: true, sources: "codex" },
+        {
+          runDailyReport: () =>
+            Effect.succeed({ daily: [{ date: "2026-07-22", totalTokens: 10 }] }),
+          runSessionReport: () =>
+            Effect.succeed({
+              sessions: [
+                {
+                  projectPath: "/Users/alex/secret-client",
+                  sessionId: "-Users-alex-secret-client",
+                },
+              ],
+            }),
+        },
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(result).toMatchObject({ status: "ok", upserted: 1 });
+    expect(uploadPayload).toMatchObject({
+      reports: [
+        {
+          payload: { daily: [{ date: "2026-07-22", totalTokens: 10 }] },
+          reportKind: "daily",
+          source: "codex",
+        },
+      ],
+      sourceStats: [{ sessionCount: 1, source: "codex" }],
+    });
+    expect(JSON.stringify(uploadPayload)).not.toContain("secret-client");
+    expect(uploadPayload?.reports).toHaveLength(1);
+  });
+
   it("keeps daily rows when the session report fails", async () => {
     const { layer } = makeTestLayer({
       initialConfig: {
@@ -473,9 +526,16 @@ describe("sync source outcomes", () => {
       },
       interactive: false,
     });
+    let uploadPayload: TestUsageIngestRequest["payload"] | undefined;
+    const auth = makeUploadAuth((request) =>
+      Effect.sync(() => {
+        uploadPayload = request.payload;
+        return { received: 1, syncedAt: "2026-07-22T00:00:00.000Z", upserted: 1 };
+      }),
+    );
     const result = await Effect.runPromise(
       syncProgram(
-        { dryRun: true, json: true, sources: "codex" },
+        { auth, dryRun: false, json: true, sources: "codex" },
         {
           runDailyReport: () =>
             Effect.succeed({ daily: [{ date: "2026-07-22", totalTokens: 10 }] }),
@@ -492,6 +552,45 @@ describe("sync source outcomes", () => {
       status: "partial",
       summary: { sessions: null },
     });
+    expect(uploadPayload?.reports).toHaveLength(1);
+    expect(uploadPayload).not.toHaveProperty("sourceStats");
+  });
+
+  it("does not overwrite lifetime session counts during a bounded sync", async () => {
+    const { layer } = makeTestLayer({
+      initialConfig: {
+        apiUrl: "https://api.tokenmaxxing.example",
+        wwwUrl: "https://tokenmaxxing.example",
+      },
+      interactive: false,
+    });
+    let uploadPayload: TestUsageIngestRequest["payload"] | undefined;
+    const auth = makeUploadAuth((request) =>
+      Effect.sync(() => {
+        uploadPayload = request.payload;
+        return { received: 1, syncedAt: "2026-07-22T00:00:00.000Z", upserted: 1 };
+      }),
+    );
+
+    await Effect.runPromise(
+      syncProgram(
+        {
+          auth,
+          dryRun: false,
+          json: true,
+          since: "2026-07-20",
+          sources: "codex",
+        },
+        {
+          runDailyReport: () =>
+            Effect.succeed({ daily: [{ date: "2026-07-22", totalTokens: 10 }] }),
+          runSessionReport: () => Effect.succeed({ sessions: [{}, {}] }),
+        },
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(uploadPayload?.reports).toHaveLength(1);
+    expect(uploadPayload).not.toHaveProperty("sourceStats");
   });
 
   it("treats a valid empty daily report as no data", async () => {
@@ -569,11 +668,18 @@ describe("uploadUsageReports", () => {
         device: { name: "Mac.local", platform: "darwin" },
         options: { json: false },
         rawReports: [],
+        sourceStats: [{ sessionCount: 42, source: "codex" }],
       }).pipe(Effect.provide(layer)),
     );
 
     expect(result.upserted).toBe(1);
-    expect(payloads).toEqual([{ device: { name: "Mac.local", platform: "darwin" }, reports: [] }]);
+    expect(payloads).toEqual([
+      {
+        device: { name: "Mac.local", platform: "darwin" },
+        reports: [],
+        sourceStats: [{ sessionCount: 42, source: "codex" }],
+      },
+    ]);
     expect(state.logs).toEqual(["Uploading usage", "Usage uploaded"]);
     expect(state.errors).toEqual([]);
   });

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -18,7 +18,6 @@ import {
   dailyCcusageCommand,
   runCcusageDailyReport,
   runCcusageSessionReport,
-  sessionCcusageCommand,
 } from "../ccusage/runner";
 import { DEFAULT_SOURCE_NAMES, resolveSources } from "../ccusage/sources";
 import {
@@ -193,6 +192,7 @@ interface UploadUsageReportsOptions {
   };
   options: Pick<SyncProgramOptions, "json" | "silent">;
   rawReports: RawUsageReportInput[];
+  sourceStats?: SourceUsageStatsInput[] | undefined;
   uploadPolicy?: UploadRetryPolicy | undefined;
 }
 
@@ -324,14 +324,6 @@ function syncProgram(options: SyncProgramOptions, runtime: SyncProgramRuntime = 
       );
       const sessionCount =
         sessionResult._tag === "success" ? sessionResult.report.sessions.length : null;
-      if (options.since === undefined && sessionResult._tag === "success") {
-        rawReports.push({
-          command: sessionCcusageCommand(source),
-          payload: sessionResult.report,
-          reportKind: "session",
-          source: source.source,
-        });
-      }
       const summary = { ...summarize(sourceRows), sessions: sessionCount };
       const result: SyncSourceResult =
         sessionResult._tag === "failure"
@@ -390,6 +382,7 @@ function syncProgram(options: SyncProgramOptions, runtime: SyncProgramRuntime = 
       device,
       options,
       rawReports,
+      sourceStats: options.since === undefined ? sourceStatsForSync(sourceResults) : undefined,
       uploadPolicy: options.uploadPolicy,
     });
     upserted = response.upserted;
@@ -411,11 +404,12 @@ function uploadUsageReports({
   device,
   options,
   rawReports,
+  sourceStats,
   uploadPolicy,
 }: UploadUsageReportsOptions) {
   return Effect.gen(function* () {
     const spinner = yield* humanSpinner("Uploading usage", options);
-    const upload = uploadUsageReportsOnce({ auth, device, rawReports }, uploadPolicy);
+    const upload = uploadUsageReportsOnce({ auth, device, rawReports, sourceStats }, uploadPolicy);
 
     return yield* upload.pipe(
       Effect.tap(() => Effect.sync(() => spinner.stop("Usage uploaded"))),
@@ -426,7 +420,7 @@ function uploadUsageReports({
 }
 
 function uploadUsageReportsOnce(
-  input: Pick<UploadUsageReportsOptions, "auth" | "device" | "rawReports">,
+  input: Pick<UploadUsageReportsOptions, "auth" | "device" | "rawReports" | "sourceStats">,
   uploadPolicy: UploadRetryPolicy | undefined,
 ) {
   const upload = () =>
@@ -434,6 +428,7 @@ function uploadUsageReportsOnce(
       payload: {
         device: input.device,
         reports: input.rawReports,
+        ...(input.sourceStats === undefined ? {} : { sourceStats: input.sourceStats }),
       },
     });
 

--- a/packages/api-contract/src/api.ts
+++ b/packages/api-contract/src/api.ts
@@ -135,8 +135,8 @@ class UsageGroup extends HttpApiGroup.make("usage")
     }),
   )
   .add(
-    // Legacy structured sync for old CLI clients. New clients send raw ccusage
-    // reports to /usage/ingest and let the API derive structured rows.
+    // Legacy structured sync for old CLI clients. New clients send normalized
+    // daily ccusage reports and aggregate source stats to /usage/ingest.
     HttpApiEndpoint.post("sync", "/usage/sync", {
       payload: SyncUsageInput,
       success: SyncUsageResponse,

--- a/packages/api-contract/src/schemas.test.ts
+++ b/packages/api-contract/src/schemas.test.ts
@@ -117,6 +117,20 @@ describe("device telemetry inputs", () => {
       },
     });
   });
+
+  it("accepts aggregate source stats on raw usage ingestion", async () => {
+    await expect(
+      Schema.decodeUnknownPromise(IngestUsageInput)({
+        device: { name: "Mac.localdomain", platform: "darwin" },
+        reports: [],
+        sourceStats: [{ sessionCount: 42, source: "codex" }],
+      }),
+    ).resolves.toEqual({
+      device: { name: "Mac.localdomain", platform: "darwin" },
+      reports: [],
+      sourceStats: [{ sessionCount: 42, source: "codex" }],
+    });
+  });
 });
 
 describe("profile daily responses", () => {

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -133,6 +133,8 @@ const SourceUsageStatsInput = Schema.Struct({
 
 type SourceUsageStatsInput = typeof SourceUsageStatsInput.Type;
 
+// `session` remains accepted for old CLIs; ingestion counts those entries in
+// memory and never persists their payloads.
 const UsageRawReportKind = Schema.Literals(["daily", "session"]);
 
 type UsageRawReportKind = typeof UsageRawReportKind.Type;
@@ -241,6 +243,7 @@ const IngestUsageInput = Schema.Struct({
     version: Schema.optional(Schema.String),
   }),
   reports: Schema.Array(RawUsageReportInput),
+  sourceStats: Schema.optional(Schema.Array(SourceUsageStatsInput)),
 }).annotate({
   parseOptions: { onExcessProperty: "error" },
 });

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -195,8 +195,9 @@ const usageSourceStats = sqliteTable(
 );
 
 /**
- * Raw ccusage reports as received from the CLI. Structured tables are derived
- * from these rows so parser changes can be backfilled server-side later.
+ * Normalized daily ccusage reports used for server-side parser backfills.
+ * Historical rows may include session reports from before aggregate-only
+ * session stats were introduced.
  */
 const usageRawBatches = sqliteTable(
   "usage_raw_batches",


### PR DESCRIPTION
## Summary

- keep session-level ccusage records on device and upload only `{ source, sessionCount }` aggregates
- persist only decoded, allowlisted daily reports at the API trust boundary
- preserve old-client compatibility by counting legacy session reports in memory and discarding their payloads before raw storage
- preserve partial-source behavior from #49: daily usage still uploads when session collection fails, without overwriting the previous session count

## Compatibility and rollout

- `sourceStats` is optional on `/usage/ingest`, so existing request bodies remain valid
- the legacy `session` report kind remains accepted during rollout, but is never persisted
- explicit source stats take precedence over legacy-derived counts
- bounded `--since` syncs do not update lifetime session counts
- deploy the API before publishing a CLI release that sends the new field
- historical R2/D1 cleanup is intentionally separate and tracked in #52

## Attribution

Supersedes #29 and preserves credit to @PazerOP for identifying the privacy gap and proposing the initial client-side mitigation. The implementation commit includes Matt as a co-author.

## Validation

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

The tests include path canaries at both the CLI request boundary and API persistence boundary, legacy-client count extraction, explicit-stat precedence, bounded syncs, and session collection failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/tokenmaxxing/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787339042&installation_model_id=428386&pr_number=53&repository=851-labs%2Ftokenmaxxing&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Ftokenmaxxing%2Fpull%2F53&signature=7b40504c54c623b3e2bf4def1e3df681ee692cccb96f291a58784be1d5d6189d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->