### PR TITLE
Add audited cleanup for raw session reports

### DIFF
--- a/.github/workflows/cleanup-raw-session-reports.yml
+++ b/.github/workflows/cleanup-raw-session-reports.yml
@@ -1,0 +1,60 @@
+name: Cleanup raw session reports
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Inventory is read-only; purge irreversibly deletes historical session reports
+        required: true
+        default: inventory
+        type: choice
+        options:
+          - inventory
+          - purge
+      expected_count:
+        description: Exact D1 session-row count from the latest inventory (required for purge)
+        required: false
+        type: string
+      confirmation:
+        description: Enter PURGE_SESSION_REPORTS to enable purge mode
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cleanup-raw-session-reports
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - run: bun install --frozen-lockfile
+
+      - name: Inventory or purge historical session reports
+        shell: bash
+        run: |
+          args=(--mode "$CLEANUP_MODE")
+          if [[ -n "$EXPECTED_COUNT" ]]; then
+            args+=(--expected-count "$EXPECTED_COUNT")
+          fi
+          if [[ -n "$PURGE_CONFIRMATION" ]]; then
+            args+=(--confirmation "$PURGE_CONFIRMATION")
+          fi
+          bun apps/api/script/purge-raw-session-reports.ts "${args[@]}"
+        env:
+          CLEANUP_MODE: ${{ inputs.mode }}
+          CLOUDFLARE_ACCOUNT_ID: 630f294bcb2c1e9b751d9fe0655a453a
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_DATABASE_NAME: tokenmaxxing-prod
+          CLOUDFLARE_BUCKET_NAME: tokenmaxxing-prod
+          EXPECTED_COUNT: ${{ inputs.expected_count }}
+          PURGE_CONFIRMATION: ${{ inputs.confirmation }}

--- a/apps/api/script/purge-raw-session-reports.test.ts
+++ b/apps/api/script/purge-raw-session-reports.test.ts
@@ -1,0 +1,364 @@
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CleanupApiError,
+  CleanupConfigurationError,
+  CleanupVerificationError,
+  encodeObjectKey,
+  executeCleanup,
+  makeCleanupApi,
+  parseCleanupOptions,
+  safeErrorMessage,
+  type CleanupApi,
+  type CleanupLogEvent,
+  type R2SessionObject,
+} from "./purge-raw-session-reports";
+
+const databaseName = "tokenmaxxing-prod";
+const databaseId = "database-id";
+
+interface FakeState {
+  events: string[];
+  failR2Key?: string | undefined;
+  r2Objects: R2SessionObject[];
+  rows: Array<{ id: string; objectKey: string }>;
+}
+
+function sessionKey(suffix: string): string {
+  return `users/user-secret/devices/device-secret/ccusage/codex/session/${suffix}.json`;
+}
+
+function makeState(count = 1): FakeState {
+  return {
+    events: [],
+    r2Objects: Array.from({ length: count }, (_, index) => ({
+      key: sessionKey(`hash-${index}`),
+      size: 100 + index,
+    })),
+    rows: Array.from({ length: count }, (_, index) => ({
+      id: `private-row-${index}`,
+      objectKey: sessionKey(`hash-${index}`),
+    })),
+  };
+}
+
+function makeFakeApi(state: FakeState): CleanupApi {
+  return {
+    deleteR2Object: (objectKey) => {
+      state.events.push("r2-delete");
+      if (state.failR2Key === objectKey) {
+        return Effect.fail(new CleanupApiError({ operation: "delete R2 object", status: 500 }));
+      }
+      const index = state.r2Objects.findIndex((object) => object.key === objectKey);
+      if (index === -1) {
+        return Effect.succeed("missing");
+      }
+      state.r2Objects.splice(index, 1);
+      return Effect.succeed("deleted");
+    },
+    listDatabases: () => {
+      state.events.push("database-list");
+      return Effect.succeed([{ name: databaseName, uuid: databaseId }]);
+    },
+    listR2SessionObjects: () => {
+      state.events.push("r2-list");
+      return Effect.succeed([...state.r2Objects]);
+    },
+    queryD1: (_databaseId, sql, params = []) => {
+      if (sql.includes("GROUP BY source")) {
+        state.events.push("d1-source-inventory");
+        return Effect.succeed({
+          rows:
+            state.rows.length === 0
+              ? []
+              : [
+                  {
+                    affected_users: 1,
+                    first_captured_at: 1_752_883_200_000,
+                    last_captured_at: 1_752_883_200_000,
+                    object_count: state.rows.length,
+                    payload_bytes: state.rows.length * 100,
+                    source: "codex",
+                  },
+                ],
+        });
+      }
+      if (sql.includes("COUNT(*) AS object_count")) {
+        state.events.push("d1-total-inventory");
+        return Effect.succeed({
+          rows: [
+            {
+              affected_users: state.rows.length === 0 ? 0 : 1,
+              first_captured_at: state.rows.length === 0 ? null : 1_752_883_200_000,
+              last_captured_at: state.rows.length === 0 ? null : 1_752_883_200_000,
+              object_count: state.rows.length,
+              payload_bytes: state.rows.length * 100,
+            },
+          ],
+        });
+      }
+      if (sql.includes("SELECT id, object_key")) {
+        state.events.push("d1-batch-read");
+        return Effect.succeed({
+          rows: state.rows.map((row) => ({ id: row.id, object_key: row.objectKey })),
+        });
+      }
+      if (sql.startsWith("DELETE FROM usage_raw_batches")) {
+        state.events.push("d1-delete");
+        const ids = new Set(params.slice(1));
+        const before = state.rows.length;
+        state.rows = state.rows.filter((row) => !ids.has(row.id));
+        return Effect.succeed({ changes: before - state.rows.length, rows: [] });
+      }
+      return Effect.fail(new CleanupApiError({ operation: "unexpected fake query" }));
+    },
+  };
+}
+
+function purgeOptions(expectedCount: number) {
+  return {
+    confirmation: "PURGE_SESSION_REPORTS",
+    expectedCount,
+    mode: "purge" as const,
+  };
+}
+
+describe("executeCleanup", () => {
+  it("inventories aggregate metadata without mutating D1 or R2", async () => {
+    const state = makeState(2);
+    const logs: CleanupLogEvent[] = [];
+
+    const result = await Effect.runPromise(
+      executeCleanup({ mode: "inventory" }, makeFakeApi(state), databaseName, (event) =>
+        logs.push(event),
+      ),
+    );
+
+    expect(result.before).toMatchObject({ d1Rows: 2, r2Objects: 2, affectedUsers: 1 });
+    expect(state.events).not.toContain("r2-delete");
+    expect(state.events).not.toContain("d1-delete");
+    expect(JSON.stringify(logs)).not.toContain("user-secret");
+    expect(JSON.stringify(logs)).not.toContain("device-secret");
+    expect(JSON.stringify(logs)).not.toContain("hash-0");
+  });
+
+  it("rejects purge before any API request when confirmation is absent", async () => {
+    const state = makeState();
+
+    await expect(
+      Effect.runPromise(
+        executeCleanup({ expectedCount: 1, mode: "purge" }, makeFakeApi(state), databaseName),
+      ),
+    ).rejects.toBeInstanceOf(CleanupConfigurationError);
+    expect(state.events).toEqual([]);
+  });
+
+  it("rejects a stale expected count without deleting anything", async () => {
+    const state = makeState(2);
+
+    await expect(
+      Effect.runPromise(executeCleanup(purgeOptions(1), makeFakeApi(state), databaseName)),
+    ).rejects.toBeInstanceOf(CleanupVerificationError);
+    expect(state.events).not.toContain("r2-delete");
+    expect(state.events).not.toContain("d1-delete");
+  });
+
+  it("deletes R2 objects before their D1 rows and verifies an empty final state", async () => {
+    const state = makeState(2);
+
+    const result = await Effect.runPromise(
+      executeCleanup(purgeOptions(2), makeFakeApi(state), databaseName),
+    );
+
+    const firstR2Delete = state.events.indexOf("r2-delete");
+    const firstD1Delete = state.events.indexOf("d1-delete");
+    expect(firstR2Delete).toBeGreaterThan(-1);
+    expect(firstD1Delete).toBeGreaterThan(firstR2Delete);
+    expect(result).toMatchObject({
+      after: { d1Rows: 0, r2Objects: 0 },
+      d1RowsDeleted: 2,
+      r2ObjectsDeleted: 2,
+    });
+  });
+
+  it("keeps D1 metadata when any R2 deletion in the batch fails", async () => {
+    const state = makeState(2);
+    state.failR2Key = state.rows[1]!.objectKey;
+
+    await expect(
+      Effect.runPromise(executeCleanup(purgeOptions(2), makeFakeApi(state), databaseName)),
+    ).rejects.toBeInstanceOf(CleanupApiError);
+    expect(state.events).not.toContain("d1-delete");
+    expect(state.rows).toHaveLength(2);
+  });
+
+  it("refuses a D1 session row whose object key is outside the session namespace", async () => {
+    const state = makeState();
+    state.rows[0]!.objectKey =
+      "users/user-secret/devices/device-secret/ccusage/codex/daily/do-not-delete.json";
+
+    await expect(
+      Effect.runPromise(executeCleanup(purgeOptions(1), makeFakeApi(state), databaseName)),
+    ).rejects.toBeInstanceOf(CleanupApiError);
+    expect(state.events).not.toContain("r2-delete");
+    expect(state.events).not.toContain("d1-delete");
+  });
+
+  it("treats missing R2 objects as an idempotent success", async () => {
+    const state = makeState();
+    state.r2Objects = [];
+
+    const result = await Effect.runPromise(
+      executeCleanup(purgeOptions(1), makeFakeApi(state), databaseName),
+    );
+
+    expect(result.r2ObjectsAlreadyMissing).toBe(1);
+    expect(result.d1RowsDeleted).toBe(1);
+    expect(result.after).toMatchObject({ d1Rows: 0, r2Objects: 0 });
+  });
+
+  it("removes exact-pattern orphaned R2 objects after D1 cleanup", async () => {
+    const state = makeState(0);
+    state.r2Objects = [{ key: sessionKey("orphan"), size: 42 }];
+
+    const result = await Effect.runPromise(
+      executeCleanup(purgeOptions(0), makeFakeApi(state), databaseName),
+    );
+
+    expect(result.r2ObjectsDeleted).toBe(1);
+    expect(result.after.r2Objects).toBe(0);
+  });
+
+  it("fails final verification when R2 still reports a session object", async () => {
+    const state = makeState(0);
+    const api = makeFakeApi(state);
+    const phantom = { key: sessionKey("phantom"), size: 42 };
+    api.listR2SessionObjects = () => Effect.succeed([phantom]);
+    api.deleteR2Object = () => Effect.succeed("missing");
+
+    await expect(
+      Effect.runPromise(executeCleanup(purgeOptions(0), api, databaseName)),
+    ).rejects.toBeInstanceOf(CleanupVerificationError);
+  });
+
+  it("requires one exact database-name match", async () => {
+    const state = makeState();
+    const api = makeFakeApi(state);
+    api.listDatabases = () =>
+      Effect.succeed([{ name: "tokenmaxxing-prod-copy", uuid: databaseId }]);
+
+    await expect(
+      Effect.runPromise(executeCleanup({ mode: "inventory" }, api, databaseName)),
+    ).rejects.toBeInstanceOf(CleanupVerificationError);
+  });
+});
+
+describe("CLI validation and Cloudflare transport", () => {
+  it("parses an explicitly confirmed purge", async () => {
+    await expect(
+      Effect.runPromise(
+        parseCleanupOptions([
+          "--mode",
+          "purge",
+          "--expected-count",
+          "12",
+          "--confirmation",
+          "PURGE_SESSION_REPORTS",
+        ]),
+      ),
+    ).resolves.toEqual({
+      confirmation: "PURGE_SESSION_REPORTS",
+      expectedCount: 12,
+      mode: "purge",
+    });
+  });
+
+  it("rejects unknown arguments and unsafe expected counts", async () => {
+    await expect(
+      Effect.runPromise(parseCleanupOptions(["--mode", "inventory", "--dryrun", "true"])),
+    ).rejects.toBeInstanceOf(CleanupConfigurationError);
+    await expect(
+      Effect.runPromise(
+        parseCleanupOptions(["--mode", "purge", "--expected-count", "9007199254740992"]),
+      ),
+    ).rejects.toBeInstanceOf(CleanupConfigurationError);
+  });
+
+  it("preserves slashes while encoding each R2 key segment", () => {
+    expect(encodeObjectKey("users/a b/session/hash?#.json")).toBe(
+      "users/a%20b/session/hash%3F%23.json",
+    );
+  });
+
+  it("paginates R2 metadata and retains only exact session object keys", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json({
+          result: [
+            { key: sessionKey("one"), size: 10 },
+            { key: "users/u/devices/d/ccusage/codex/daily/keep.json", size: 20 },
+          ],
+          result_info: { cursor: "next-page", is_truncated: true },
+          success: true,
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          result: [{ key: sessionKey("two"), size: 30 }],
+          result_info: { is_truncated: false },
+          success: true,
+        }),
+      );
+    const api = makeCleanupApi(
+      {
+        accountId: "account",
+        apiToken: "secret-token",
+        bucketName: "bucket",
+        databaseName,
+      },
+      fetchMock,
+    );
+
+    await expect(Effect.runPromise(api.listR2SessionObjects())).resolves.toEqual([
+      { key: sessionKey("one"), size: 10 },
+      { key: sessionKey("two"), size: 30 },
+    ]);
+    const secondRequest = fetchMock.mock.calls[1]?.[0];
+    expect(typeof secondRequest).toBe("string");
+    expect(secondRequest).toContain("cursor=next-page");
+  });
+
+  it("rejects a 2xx R2 delete response whose Cloudflare success flag is false", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      Response.json({
+        errors: [{ message: sessionKey("private") }],
+        result: null,
+        success: false,
+      }),
+    );
+    const api = makeCleanupApi(
+      {
+        accountId: "account",
+        apiToken: "secret-token",
+        bucketName: "bucket",
+        databaseName,
+      },
+      fetchMock,
+    );
+
+    await expect(Effect.runPromise(api.deleteR2Object(sessionKey("private")))).rejects.toEqual(
+      expect.objectContaining({ _tag: "CleanupApiError", operation: "delete R2 object" }),
+    );
+  });
+
+  it("sanitizes Cloudflare failures without exposing keys or response bodies", () => {
+    const error = new CleanupApiError({ operation: "delete R2 object", status: 500 });
+    const message = safeErrorMessage(error);
+
+    expect(message).toBe("Cloudflare operation failed: delete R2 object (HTTP 500).");
+    expect(message).not.toContain("user-secret");
+    expect(message).not.toContain("secret-token");
+  });
+});

--- a/apps/api/script/purge-raw-session-reports.ts
+++ b/apps/api/script/purge-raw-session-reports.ts
@@ -1,0 +1,702 @@
+import { Data, Effect } from "effect";
+
+const CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4";
+const DEFAULT_BATCH_SIZE = 50;
+const SESSION_OBJECT_KEY_PATTERN =
+  /^users\/[^/]+\/devices\/[^/]+\/ccusage\/[^/]+\/session\/[^/]+\.json$/;
+
+type CleanupMode = "inventory" | "purge";
+
+interface CleanupOptions {
+  confirmation?: string | undefined;
+  expectedCount?: number | undefined;
+  mode: CleanupMode;
+}
+
+interface CleanupEnvironment {
+  accountId: string;
+  apiToken: string;
+  bucketName: string;
+  databaseName: string;
+}
+
+interface DatabaseRecord {
+  name: string;
+  uuid: string;
+}
+
+interface D1QueryResult {
+  changes?: number | undefined;
+  rows: readonly Record<string, unknown>[];
+}
+
+interface SessionBatchRow {
+  id: string;
+  objectKey: string;
+}
+
+interface SessionSourceInventory {
+  affectedUsers: number;
+  firstCapturedAt: string | null;
+  lastCapturedAt: string | null;
+  objectCount: number;
+  payloadBytes: number;
+  source: string;
+}
+
+interface SessionInventory {
+  affectedUsers: number;
+  d1Rows: number;
+  firstCapturedAt: string | null;
+  lastCapturedAt: string | null;
+  payloadBytes: number;
+  r2Objects: number;
+  r2PayloadBytes: number;
+  sources: readonly SessionSourceInventory[];
+}
+
+interface CleanupResult {
+  after: SessionInventory;
+  before: SessionInventory;
+  d1RowsDeleted: number;
+  r2ObjectsAlreadyMissing: number;
+  r2ObjectsDeleted: number;
+}
+
+type CleanupLogEvent =
+  | { inventory: SessionInventory; type: "inventory" }
+  | {
+      d1RowsDeleted: number;
+      r2ObjectsAlreadyMissing: number;
+      r2ObjectsDeleted: number;
+      type: "purge-complete";
+    };
+
+interface CleanupApi {
+  deleteR2Object(objectKey: string): Effect.Effect<"deleted" | "missing", CleanupApiError>;
+  listDatabases(name: string): Effect.Effect<readonly DatabaseRecord[], CleanupApiError>;
+  listR2SessionObjects(): Effect.Effect<readonly R2SessionObject[], CleanupApiError>;
+  queryD1(
+    databaseId: string,
+    sql: string,
+    params?: readonly string[],
+  ): Effect.Effect<D1QueryResult, CleanupApiError>;
+}
+
+interface R2SessionObject {
+  key: string;
+  size: number;
+}
+
+class CleanupConfigurationError extends Data.TaggedError("CleanupConfigurationError")<{
+  readonly message: string;
+}> {}
+
+class CleanupApiError extends Data.TaggedError("CleanupApiError")<{
+  readonly operation: string;
+  readonly status?: number | undefined;
+}> {}
+
+class CleanupVerificationError extends Data.TaggedError("CleanupVerificationError")<{
+  readonly message: string;
+}> {}
+
+type CleanupError = CleanupApiError | CleanupConfigurationError | CleanupVerificationError;
+
+const TOTAL_INVENTORY_SQL = `
+SELECT
+  COUNT(*) AS object_count,
+  COALESCE(SUM(payload_bytes), 0) AS payload_bytes,
+  COUNT(DISTINCT user_id) AS affected_users,
+  MIN(captured_at) AS first_captured_at,
+  MAX(captured_at) AS last_captured_at
+FROM usage_raw_batches
+WHERE report_kind = 'session'
+`;
+
+const SOURCE_INVENTORY_SQL = `
+SELECT
+  source,
+  COUNT(*) AS object_count,
+  COALESCE(SUM(payload_bytes), 0) AS payload_bytes,
+  COUNT(DISTINCT user_id) AS affected_users,
+  MIN(captured_at) AS first_captured_at,
+  MAX(captured_at) AS last_captured_at
+FROM usage_raw_batches
+WHERE report_kind = 'session'
+GROUP BY source
+ORDER BY source
+`;
+
+const SESSION_BATCH_SQL = `
+SELECT id, object_key
+FROM usage_raw_batches
+WHERE report_kind = 'session'
+ORDER BY id
+LIMIT ?
+`;
+
+function parseCleanupOptions(
+  args: readonly string[],
+): Effect.Effect<CleanupOptions, CleanupConfigurationError> {
+  const knownFlags = new Set(["confirmation", "expected-count", "mode"]);
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (flag === undefined || !flag.startsWith("--") || value === undefined) {
+      return Effect.fail(
+        new CleanupConfigurationError({
+          message: "Arguments must be provided as --name value pairs.",
+        }),
+      );
+    }
+    const name = flag.slice(2);
+    if (!knownFlags.has(name)) {
+      return Effect.fail(
+        new CleanupConfigurationError({ message: `Unknown argument: --${name}.` }),
+      );
+    }
+    values.set(name, value);
+  }
+
+  const mode = values.get("mode");
+  if (mode !== "inventory" && mode !== "purge") {
+    return Effect.fail(
+      new CleanupConfigurationError({ message: "--mode must be inventory or purge." }),
+    );
+  }
+
+  const expectedCountValue = values.get("expected-count");
+  const expectedCount =
+    expectedCountValue === undefined ? undefined : Number.parseInt(expectedCountValue, 10);
+  if (
+    expectedCountValue !== undefined &&
+    (!/^\d+$/.test(expectedCountValue) ||
+      expectedCount === undefined ||
+      !Number.isSafeInteger(expectedCount) ||
+      expectedCount < 0)
+  ) {
+    return Effect.fail(
+      new CleanupConfigurationError({
+        message: "--expected-count must be a non-negative integer.",
+      }),
+    );
+  }
+
+  return Effect.succeed({
+    confirmation: values.get("confirmation"),
+    expectedCount,
+    mode,
+  });
+}
+
+function readCleanupEnvironment(
+  env: Record<string, string | undefined>,
+): Effect.Effect<CleanupEnvironment, CleanupConfigurationError> {
+  const required = [
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CLOUDFLARE_API_TOKEN",
+    "CLOUDFLARE_BUCKET_NAME",
+    "CLOUDFLARE_DATABASE_NAME",
+  ] as const;
+  const missing = required.filter((name) => !env[name]);
+  if (missing.length > 0) {
+    return Effect.fail(
+      new CleanupConfigurationError({
+        message: `Missing required environment variables: ${missing.join(", ")}.`,
+      }),
+    );
+  }
+
+  return Effect.succeed({
+    accountId: env.CLOUDFLARE_ACCOUNT_ID!,
+    apiToken: env.CLOUDFLARE_API_TOKEN!,
+    bucketName: env.CLOUDFLARE_BUCKET_NAME!,
+    databaseName: env.CLOUDFLARE_DATABASE_NAME!,
+  });
+}
+
+function makeCleanupApi(
+  environment: CleanupEnvironment,
+  fetchImplementation: typeof fetch = fetch,
+): CleanupApi {
+  const accountPath = `${CLOUDFLARE_API_BASE_URL}/accounts/${encodeURIComponent(environment.accountId)}`;
+  const headers = {
+    Authorization: `Bearer ${environment.apiToken}`,
+    "Content-Type": "application/json",
+  };
+
+  const requestJson = <A>(
+    operation: string,
+    url: string,
+    init?: RequestInit,
+  ): Effect.Effect<A, CleanupApiError> =>
+    Effect.tryPromise({
+      try: async () => {
+        const response = await fetchImplementation(url, { ...init, headers });
+        if (!response.ok) {
+          return Promise.reject(new CleanupApiError({ operation, status: response.status }));
+        }
+
+        const body = (await response.json()) as CloudflareEnvelope<A>;
+        if (body.success !== true) {
+          return Promise.reject(new CleanupApiError({ operation, status: response.status }));
+        }
+        return body.result;
+      },
+      catch: (error) =>
+        error instanceof CleanupApiError ? error : new CleanupApiError({ operation }),
+    });
+
+  return {
+    deleteR2Object: (objectKey) =>
+      Effect.tryPromise({
+        try: async () => {
+          const response = await fetchImplementation(
+            `${accountPath}/r2/buckets/${encodeURIComponent(environment.bucketName)}/objects/${encodeObjectKey(objectKey)}`,
+            { headers, method: "DELETE" },
+          );
+          if (response.status === 404) {
+            return "missing" as const;
+          }
+          if (!response.ok) {
+            return Promise.reject(
+              new CleanupApiError({ operation: "delete R2 object", status: response.status }),
+            );
+          }
+          const body = (await response.json()) as CloudflareEnvelope<unknown>;
+          if (body.success !== true) {
+            return Promise.reject(
+              new CleanupApiError({ operation: "delete R2 object", status: response.status }),
+            );
+          }
+          return "deleted" as const;
+        },
+        catch: (error) =>
+          error instanceof CleanupApiError
+            ? error
+            : new CleanupApiError({ operation: "delete R2 object" }),
+      }),
+    listDatabases: (name) =>
+      requestJson<readonly CloudflareDatabaseRecord[]>(
+        "list D1 databases",
+        `${accountPath}/d1/database?name=${encodeURIComponent(name)}&per_page=100`,
+      ).pipe(
+        Effect.flatMap((records) => {
+          const databases = records.flatMap((record) =>
+            typeof record.name === "string" && typeof record.uuid === "string"
+              ? [{ name: record.name, uuid: record.uuid }]
+              : [],
+          );
+          return databases.length === records.length
+            ? Effect.succeed(databases)
+            : Effect.fail(new CleanupApiError({ operation: "decode D1 database list" }));
+        }),
+      ),
+    listR2SessionObjects: () =>
+      Effect.gen(function* () {
+        const objects: R2SessionObject[] = [];
+        let cursor: string | undefined;
+        do {
+          const search = new URLSearchParams({ per_page: "1000", prefix: "users/" });
+          if (cursor !== undefined) {
+            search.set("cursor", cursor);
+          }
+          const response = yield* requestCloudflareEnvelope<readonly CloudflareR2Object[]>(
+            fetchImplementation,
+            "list R2 objects",
+            `${accountPath}/r2/buckets/${encodeURIComponent(environment.bucketName)}/objects?${search.toString()}`,
+            headers,
+          );
+          for (const object of response.result) {
+            if (typeof object.key !== "string" || typeof object.size !== "number") {
+              return yield* Effect.fail(
+                new CleanupApiError({ operation: "decode R2 object metadata" }),
+              );
+            }
+            if (SESSION_OBJECT_KEY_PATTERN.test(object.key)) {
+              objects.push({ key: object.key, size: object.size });
+            }
+          }
+          const isTruncated =
+            response.resultInfo?.is_truncated === true || response.resultInfo?.isTruncated === true;
+          cursor = isTruncated ? response.resultInfo?.cursor : undefined;
+          if (isTruncated && !cursor) {
+            return yield* Effect.fail(new CleanupApiError({ operation: "paginate R2 objects" }));
+          }
+        } while (cursor !== undefined);
+
+        return objects;
+      }),
+    queryD1: (databaseId, sql, params = []) =>
+      requestJson<readonly CloudflareD1QueryResult[]>(
+        "query D1 database",
+        `${accountPath}/d1/database/${encodeURIComponent(databaseId)}/query`,
+        {
+          body: JSON.stringify({ params, sql }),
+          method: "POST",
+        },
+      ).pipe(
+        Effect.flatMap((results) => {
+          const result = results[0];
+          if (results.length !== 1 || result?.success !== true || !Array.isArray(result.results)) {
+            return Effect.fail(new CleanupApiError({ operation: "decode D1 query result" }));
+          }
+          return Effect.succeed({ changes: result.meta?.changes, rows: result.results });
+        }),
+      ),
+  };
+}
+
+function requestCloudflareEnvelope<A>(
+  fetchImplementation: typeof fetch,
+  operation: string,
+  url: string,
+  headers: Record<string, string>,
+): Effect.Effect<{ result: A; resultInfo?: CloudflareResultInfo | undefined }, CleanupApiError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const response = await fetchImplementation(url, { headers });
+      if (!response.ok) {
+        return Promise.reject(new CleanupApiError({ operation, status: response.status }));
+      }
+      const body = (await response.json()) as CloudflareEnvelope<A>;
+      if (body.success !== true) {
+        return Promise.reject(new CleanupApiError({ operation, status: response.status }));
+      }
+      return { result: body.result, resultInfo: body.result_info };
+    },
+    catch: (error) =>
+      error instanceof CleanupApiError ? error : new CleanupApiError({ operation }),
+  });
+}
+
+interface CloudflareEnvelope<A> {
+  result: A;
+  result_info?: CloudflareResultInfo | undefined;
+  success: boolean;
+}
+
+interface CloudflareResultInfo {
+  cursor?: string | undefined;
+  isTruncated?: boolean | undefined;
+  is_truncated?: boolean | undefined;
+}
+
+interface CloudflareDatabaseRecord {
+  name?: unknown;
+  uuid?: unknown;
+}
+
+interface CloudflareD1QueryResult {
+  meta?: { changes?: number | undefined } | undefined;
+  results?: readonly Record<string, unknown>[] | undefined;
+  success?: boolean | undefined;
+}
+
+interface CloudflareR2Object {
+  key?: unknown;
+  size?: unknown;
+}
+
+function executeCleanup(
+  options: CleanupOptions,
+  api: CleanupApi,
+  databaseName: string,
+  log: (event: CleanupLogEvent) => void = (event) => console.log(JSON.stringify(event)),
+): Effect.Effect<CleanupResult, CleanupError> {
+  return Effect.gen(function* () {
+    yield* validatePurgeOptions(options);
+    const databaseId = yield* resolveDatabaseId(api, databaseName);
+    const before = yield* inventorySessionReports(api, databaseId);
+    log({ inventory: before, type: "inventory" });
+
+    if (options.mode === "inventory") {
+      return {
+        after: before,
+        before,
+        d1RowsDeleted: 0,
+        r2ObjectsAlreadyMissing: 0,
+        r2ObjectsDeleted: 0,
+      };
+    }
+
+    if (options.expectedCount !== before.d1Rows) {
+      return yield* Effect.fail(
+        new CleanupVerificationError({
+          message: `Expected ${options.expectedCount} D1 session rows, found ${before.d1Rows}.`,
+        }),
+      );
+    }
+
+    let d1RowsDeleted = 0;
+    let r2ObjectsAlreadyMissing = 0;
+    let r2ObjectsDeleted = 0;
+
+    while (true) {
+      const rows = yield* readSessionBatch(api, databaseId, DEFAULT_BATCH_SIZE);
+      if (rows.length === 0) {
+        break;
+      }
+
+      const deleteResults = yield* Effect.forEach(
+        rows,
+        (row) => api.deleteR2Object(row.objectKey),
+        { concurrency: 5 },
+      );
+      r2ObjectsDeleted += deleteResults.filter((result) => result === "deleted").length;
+      r2ObjectsAlreadyMissing += deleteResults.filter((result) => result === "missing").length;
+
+      const changes = yield* deleteD1Rows(
+        api,
+        databaseId,
+        rows.map((row) => row.id),
+      );
+      if (changes !== rows.length) {
+        return yield* Effect.fail(
+          new CleanupVerificationError({
+            message: `D1 deleted ${changes} rows from a ${rows.length}-row batch.`,
+          }),
+        );
+      }
+      d1RowsDeleted += changes;
+    }
+
+    const orphanedObjects = yield* api.listR2SessionObjects();
+    const orphanDeleteResults = yield* Effect.forEach(
+      orphanedObjects,
+      (object) => api.deleteR2Object(object.key),
+      { concurrency: 5 },
+    );
+    r2ObjectsDeleted += orphanDeleteResults.filter((result) => result === "deleted").length;
+    r2ObjectsAlreadyMissing += orphanDeleteResults.filter((result) => result === "missing").length;
+
+    const after = yield* inventorySessionReports(api, databaseId);
+    if (after.d1Rows !== 0 || after.r2Objects !== 0) {
+      return yield* Effect.fail(
+        new CleanupVerificationError({
+          message: `Cleanup verification failed: ${after.d1Rows} D1 rows and ${after.r2Objects} R2 objects remain.`,
+        }),
+      );
+    }
+
+    log({ d1RowsDeleted, r2ObjectsAlreadyMissing, r2ObjectsDeleted, type: "purge-complete" });
+    return { after, before, d1RowsDeleted, r2ObjectsAlreadyMissing, r2ObjectsDeleted };
+  });
+}
+
+function validatePurgeOptions(
+  options: CleanupOptions,
+): Effect.Effect<void, CleanupConfigurationError> {
+  if (options.mode === "inventory") {
+    return Effect.void;
+  }
+  if (options.confirmation !== "PURGE_SESSION_REPORTS") {
+    return Effect.fail(
+      new CleanupConfigurationError({
+        message: "Purge requires --confirmation PURGE_SESSION_REPORTS.",
+      }),
+    );
+  }
+  if (options.expectedCount === undefined) {
+    return Effect.fail(
+      new CleanupConfigurationError({ message: "Purge requires --expected-count." }),
+    );
+  }
+  return Effect.void;
+}
+
+function resolveDatabaseId(
+  api: CleanupApi,
+  databaseName: string,
+): Effect.Effect<string, CleanupApiError | CleanupVerificationError> {
+  return Effect.gen(function* () {
+    const databases = (yield* api.listDatabases(databaseName)).filter(
+      (database) => database.name === databaseName,
+    );
+    if (databases.length !== 1) {
+      return yield* Effect.fail(
+        new CleanupVerificationError({
+          message: `Expected exactly one D1 database named ${databaseName}, found ${databases.length}.`,
+        }),
+      );
+    }
+    return databases[0]!.uuid;
+  });
+}
+
+function inventorySessionReports(
+  api: CleanupApi,
+  databaseId: string,
+): Effect.Effect<SessionInventory, CleanupApiError> {
+  return Effect.gen(function* () {
+    const [totalResult, sourceResult, r2Objects] = yield* Effect.all(
+      [
+        api.queryD1(databaseId, TOTAL_INVENTORY_SQL),
+        api.queryD1(databaseId, SOURCE_INVENTORY_SQL),
+        api.listR2SessionObjects(),
+      ],
+      { concurrency: 3 },
+    );
+    const total = totalResult.rows[0];
+    if (total === undefined) {
+      return yield* Effect.fail(new CleanupApiError({ operation: "decode D1 inventory" }));
+    }
+
+    const sources = yield* Effect.forEach(sourceResult.rows, decodeSourceInventory);
+    return {
+      affectedUsers: yield* readNumber(total, "affected_users", "decode D1 inventory"),
+      d1Rows: yield* readNumber(total, "object_count", "decode D1 inventory"),
+      firstCapturedAt: yield* readTimestamp(total, "first_captured_at"),
+      lastCapturedAt: yield* readTimestamp(total, "last_captured_at"),
+      payloadBytes: yield* readNumber(total, "payload_bytes", "decode D1 inventory"),
+      r2Objects: r2Objects.length,
+      r2PayloadBytes: r2Objects.reduce((sum, object) => sum + object.size, 0),
+      sources,
+    };
+  });
+}
+
+function decodeSourceInventory(
+  row: Record<string, unknown>,
+): Effect.Effect<SessionSourceInventory, CleanupApiError> {
+  return Effect.gen(function* () {
+    const source = row.source;
+    if (typeof source !== "string") {
+      return yield* Effect.fail(new CleanupApiError({ operation: "decode D1 source inventory" }));
+    }
+    return {
+      affectedUsers: yield* readNumber(row, "affected_users", "decode D1 source inventory"),
+      firstCapturedAt: yield* readTimestamp(row, "first_captured_at"),
+      lastCapturedAt: yield* readTimestamp(row, "last_captured_at"),
+      objectCount: yield* readNumber(row, "object_count", "decode D1 source inventory"),
+      payloadBytes: yield* readNumber(row, "payload_bytes", "decode D1 source inventory"),
+      source,
+    };
+  });
+}
+
+function readSessionBatch(
+  api: CleanupApi,
+  databaseId: string,
+  batchSize: number,
+): Effect.Effect<readonly SessionBatchRow[], CleanupApiError> {
+  return api.queryD1(databaseId, SESSION_BATCH_SQL, [String(batchSize)]).pipe(
+    Effect.flatMap((result) =>
+      Effect.forEach(result.rows, (row) => {
+        const id = row.id;
+        const objectKey = row.object_key;
+        return typeof id === "string" &&
+          typeof objectKey === "string" &&
+          SESSION_OBJECT_KEY_PATTERN.test(objectKey)
+          ? Effect.succeed({ id, objectKey })
+          : Effect.fail(new CleanupApiError({ operation: "decode D1 session batch" }));
+      }),
+    ),
+  );
+}
+
+function deleteD1Rows(
+  api: CleanupApi,
+  databaseId: string,
+  ids: readonly string[],
+): Effect.Effect<number, CleanupApiError> {
+  if (ids.length === 0) {
+    return Effect.succeed(0);
+  }
+  const placeholders = ids.map(() => "?").join(", ");
+  return api
+    .queryD1(
+      databaseId,
+      `DELETE FROM usage_raw_batches WHERE report_kind = ? AND id IN (${placeholders})`,
+      ["session", ...ids],
+    )
+    .pipe(
+      Effect.flatMap((result) =>
+        result.changes === undefined
+          ? Effect.fail(new CleanupApiError({ operation: "decode D1 delete result" }))
+          : Effect.succeed(result.changes),
+      ),
+    );
+}
+
+function readNumber(
+  row: Record<string, unknown>,
+  field: string,
+  operation: string,
+): Effect.Effect<number, CleanupApiError> {
+  const value = row[field];
+  return typeof value === "number" && Number.isFinite(value)
+    ? Effect.succeed(value)
+    : Effect.fail(new CleanupApiError({ operation }));
+}
+
+function readTimestamp(
+  row: Record<string, unknown>,
+  field: string,
+): Effect.Effect<string | null, CleanupApiError> {
+  const value = row[field];
+  if (value === null) {
+    return Effect.succeed(null);
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return Effect.fail(new CleanupApiError({ operation: "decode D1 inventory timestamp" }));
+  }
+  return Effect.succeed(new Date(value).toISOString());
+}
+
+function encodeObjectKey(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+function safeErrorMessage(error: unknown): string {
+  if (error instanceof CleanupApiError) {
+    const status = error.status === undefined ? "" : ` (HTTP ${error.status})`;
+    return `Cloudflare operation failed: ${error.operation}${status}.`;
+  }
+  if (error instanceof CleanupConfigurationError || error instanceof CleanupVerificationError) {
+    return error.message;
+  }
+  return "Cleanup failed with an unexpected error.";
+}
+
+function runCli(): Effect.Effect<void, CleanupError> {
+  return Effect.gen(function* () {
+    const options = yield* parseCleanupOptions(process.argv.slice(2));
+    const environment = yield* readCleanupEnvironment(process.env);
+    const api = makeCleanupApi(environment);
+    yield* executeCleanup(options, api, environment.databaseName);
+  });
+}
+
+if (import.meta.main) {
+  Effect.runPromise(runCli()).catch((error: unknown) => {
+    console.error(safeErrorMessage(error));
+    process.exitCode = 1;
+  });
+}
+
+export {
+  CleanupApiError,
+  CleanupConfigurationError,
+  CleanupVerificationError,
+  encodeObjectKey,
+  executeCleanup,
+  makeCleanupApi,
+  parseCleanupOptions,
+  readCleanupEnvironment,
+  safeErrorMessage,
+  SESSION_OBJECT_KEY_PATTERN,
+};
+
+export type {
+  CleanupApi,
+  CleanupEnvironment,
+  CleanupLogEvent,
+  CleanupOptions,
+  CleanupResult,
+  D1QueryResult,
+  R2SessionObject,
+  SessionInventory,
+};

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["@cloudflare/workers-types", "bun"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["script/**/*.ts", "src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- add a manually dispatched, inventory-first workflow for historical raw session reports
- inventory aggregate D1 and R2 metadata without reading payloads or logging identifiers
- gate purge behind an exact D1 row count and `PURGE_SESSION_REPORTS` confirmation
- delete R2 objects before D1 metadata in resumable batches, then remove exact-pattern R2 orphans
- require final D1 and R2 inventories to both be empty

## Safety

- inventory is the default and performs no writes
- purge validates every D1 object key against the historical session-key namespace
- partial R2 failures retain the corresponding D1 deletion manifest
- missing R2 objects are treated idempotently
- Cloudflare failures are sanitized; payloads, object keys, and user/device IDs are never logged
- production inventory and purge are intentionally not run by this PR

## Validation

- `bun run fmt`
- `bun run lint` (one pre-existing warning in `apps/api/src/leaderboard/service.test.ts`)
- `bun run typecheck`
- `bun run test`

Refs #52

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/tokenmaxxing/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787339897&installation_model_id=428386&pr_number=54&repository=851-labs%2Ftokenmaxxing&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Ftokenmaxxing%2Fpull%2F54&signature=c6f00f4662f282c6d6e04dc2691e55386f9c2130183033a6af9fdf112bd61093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->