### PR TITLE
fix: add route-aware favicons

### DIFF
--- a/apps/www/src/lib/favicon.ts
+++ b/apps/www/src/lib/favicon.ts
@@ -1,0 +1,7 @@
+const DEFAULT_FAVICON_URL = "https://avatars.githubusercontent.com/u/149856362?v=4";
+
+function profileFaviconUrl(avatarUrl: string | null): string {
+  return avatarUrl ?? DEFAULT_FAVICON_URL;
+}
+
+export { DEFAULT_FAVICON_URL, profileFaviconUrl };

--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -2,10 +2,15 @@ import { useMemo, useState } from "react";
 import { LinkSimple } from "@phosphor-icons/react/ssr";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
-import type { ProfileDailyResponse, ProfileDailyRow } from "@tokenmaxxing/api-contract";
+import type {
+  ProfileDailyResponse,
+  ProfileDailyRow,
+  ProfileResponse,
+} from "@tokenmaxxing/api-contract";
 
 type DailyRow = typeof ProfileDailyRow.Type;
 type DailyRange = (typeof ProfileDailyResponse.Type)["range"];
+type Profile = typeof ProfileResponse.Type;
 
 import { Heatmap } from "../components/charts/heatmap";
 import { MonthBars } from "../components/charts/month-bars";
@@ -24,6 +29,7 @@ import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { Code } from "../components/ui/code";
 import { isApiError } from "../lib/api";
+import { profileFaviconUrl } from "../lib/favicon";
 import { breadcrumbSchema, profilePageSchema } from "../lib/jsonld";
 import {
   OG_IMAGE_HEIGHT,
@@ -57,40 +63,44 @@ const Route = createFileRoute("/$user")({
       return {};
     }
 
-    const profile = loaderData.profile;
-    const title = profileOgTitle(profile);
-    const description = profileOgDescription(profile);
-    const image = profileOgImageUrl(profile);
-    const url = profileUrl(profile);
-
-    return {
-      meta: [
-        { title },
-        { name: "description", content: description },
-        { property: "og:title", content: title },
-        { property: "og:description", content: description },
-        { property: "og:type", content: "profile" },
-        { property: "og:url", content: url },
-        { property: "og:image", content: image },
-        { property: "og:image:width", content: String(OG_IMAGE_WIDTH) },
-        { property: "og:image:height", content: String(OG_IMAGE_HEIGHT) },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: image },
-      ],
-      scripts: [
-        {
-          type: "application/ld+json",
-          children: JSON.stringify(profilePageSchema(profile)),
-        },
-        {
-          type: "application/ld+json",
-          children: JSON.stringify(breadcrumbSchema(profile.user.login, url)),
-        },
-      ],
-    };
+    return profileHead(loaderData.profile);
   },
   component: ProfilePage,
 });
+
+function profileHead(profile: Profile) {
+  const title = profileOgTitle(profile);
+  const description = profileOgDescription(profile);
+  const image = profileOgImageUrl(profile);
+  const url = profileUrl(profile);
+
+  return {
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:type", content: "profile" },
+      { property: "og:url", content: url },
+      { property: "og:image", content: image },
+      { property: "og:image:width", content: String(OG_IMAGE_WIDTH) },
+      { property: "og:image:height", content: String(OG_IMAGE_HEIGHT) },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:image", content: image },
+    ],
+    links: [{ rel: "icon", href: profileFaviconUrl(profile.user.avatarUrl) }],
+    scripts: [
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(profilePageSchema(profile)),
+      },
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(breadcrumbSchema(profile.user.login, url)),
+      },
+    ],
+  };
+}
 
 const countFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
 
@@ -425,4 +435,4 @@ function calendarYearEnd(date: string): string {
   return `${date.slice(0, 4)}-12-31`;
 }
 
-export { deriveCharts, Route };
+export { deriveCharts, profileHead, Route };

--- a/apps/www/src/routes/-$user.test.ts
+++ b/apps/www/src/routes/-$user.test.ts
@@ -1,10 +1,34 @@
 import { describe, expect, it } from "vitest";
-import type { ProfileDailyResponse, ProfileDailyRow } from "@tokenmaxxing/api-contract";
+import type {
+  ProfileDailyResponse,
+  ProfileDailyRow,
+  ProfileResponse,
+} from "@tokenmaxxing/api-contract";
 
-import { deriveCharts } from "./$user";
+import { DEFAULT_FAVICON_URL } from "../lib/favicon";
+import { deriveCharts, profileHead } from "./$user";
 
 type DailyRange = (typeof ProfileDailyResponse.Type)["range"];
 type DailyRow = typeof ProfileDailyRow.Type;
+type Profile = typeof ProfileResponse.Type;
+
+describe("profile metadata", () => {
+  it("uses the profile avatar as the favicon", () => {
+    const avatarUrl = "https://github.com/pondorasti.png";
+
+    expect(profileHead(profile(avatarUrl)).links).toContainEqual({
+      rel: "icon",
+      href: avatarUrl,
+    });
+  });
+
+  it("falls back to the default gradient when the profile has no avatar", () => {
+    expect(profileHead(profile(null)).links).toContainEqual({
+      rel: "icon",
+      href: DEFAULT_FAVICON_URL,
+    });
+  });
+});
 
 describe("deriveCharts", () => {
   it("fills sparse usage rows across the server-provided chart range", () => {
@@ -149,5 +173,32 @@ function dailyRow({
     key,
     outputTokens: 0,
     totalTokens,
+  };
+}
+
+function profile(avatarUrl: string | null): Profile {
+  return {
+    stats: {
+      activeDays: 7,
+      avgSpendPerActiveDay: 17.64,
+      currentStreakDays: 3,
+      deviceCount: 2,
+      firstDate: "2026-01-01",
+      lastDate: "2026-06-21",
+      leaderboardRank: 7,
+      longestStreakDays: 12,
+      peakDay: { date: "2026-06-20", spendUsd: 42 },
+      sessionCount: 14,
+      sources: ["claude", "codex"],
+      topModel: { model: "claude-opus", spendUsd: 42 },
+      totalSpendUsd: 123.45,
+      totalTokens: 987_654,
+    },
+    user: {
+      avatarUrl,
+      id: "user_123",
+      login: "pondorasti",
+      name: null,
+    },
   };
 }

--- a/apps/www/src/routes/-root.test.ts
+++ b/apps/www/src/routes/-root.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "vitest";
 
+import { DEFAULT_FAVICON_URL } from "../lib/favicon";
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from "../lib/og";
 import { DEFAULT_OG_IMAGE_URL, rootHead } from "./__root";
 
 describe("root metadata", () => {
+  it("uses the 851 Labs gradient as the default favicon", () => {
+    const head = rootHead();
+
+    expect(linkHref(head.links, "icon")).toBe(DEFAULT_FAVICON_URL);
+  });
+
   it("uses pondorasti profile image as the non-profile OG fallback", () => {
     const head = rootHead();
 
@@ -14,6 +21,10 @@ describe("root metadata", () => {
     expect(metaContent(head.meta, "name", "twitter:image")).toBe(DEFAULT_OG_IMAGE_URL);
   });
 });
+
+function linkHref(links: ReturnType<typeof rootHead>["links"], rel: string): string | undefined {
+  return links.find((entry) => entry.rel === rel)?.href;
+}
 
 function metaContent(
   meta: ReturnType<typeof rootHead>["meta"],

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import type { QueryClient } from "@tanstack/react-query";
 
 import { Footer } from "../components/footer";
 import { Nav } from "../components/nav";
+import { DEFAULT_FAVICON_URL } from "../lib/favicon";
 import { organizationSchema, webSiteSchema } from "../lib/jsonld";
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH, SITE_ORIGIN } from "../lib/og";
 import styles from "../styles.css?url";
@@ -43,7 +44,10 @@ function rootHead() {
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:image", content: DEFAULT_OG_IMAGE_URL },
     ],
-    links: [{ rel: "stylesheet", href: styles }],
+    links: [
+      { rel: "icon", href: DEFAULT_FAVICON_URL },
+      { rel: "stylesheet", href: styles },
+    ],
     scripts: [
       {
         type: "application/ld+json",


### PR DESCRIPTION
## Summary

- use the exact 851 Labs GitHub organization gradient as the default favicon across the site
- use each loaded profile's avatar as the route-specific favicon on `/{username}`
- fall back to the default gradient when a profile does not have an avatar
- add route metadata coverage for the default, profile-avatar, and null-avatar cases

## Why

The site did not emit any favicon link, so non-profile pages had no branded browser icon and public profile pages could not reflect the profile owner even though the avatar was already available in the profile loader data.

## Implementation

A shared favicon helper owns the 851 Labs fallback URL. The root route publishes that default favicon for every page, while the profile route adds the loaded `profile.user.avatarUrl` as its more-specific icon. This stays server-rendered through TanStack Router head metadata, updates correctly during navigation, and requires no additional client-side request or state.

## User impact

- `tokenmaxxing.sh` and static pages show the existing 851 Labs gradient branding in browser tabs and bookmarks.
- `tokenmaxxing.sh/{username}` shows that user's profile picture in browser tabs and bookmarks.
- Profiles without an avatar still receive the branded gradient.

## Validation

- `bun run fmt` — passed
- `bun run lint` — passed, with one pre-existing warning in `apps/api/src/leaderboard/service.test.ts`
- all five workspace typechecks from the pre-commit hook — passed
- `bun run --filter @tokenmaxxing/www test` — 23/23 tests passed
- `bun run --filter @tokenmaxxing/www build` — production client and SSR builds passed
- local production SSR preview:
  - `/` rendered the 851 Labs avatar favicon
  - `/jacethings` rendered the profile avatar as the route-specific favicon

The full workspace test hook also ran. Two unrelated tests in `apps/api/src/public-visibility.test.ts` fail in this local runtime because the experimental `node:sqlite` statement lacks `setReturnArrays`; the web package and all favicon-specific tests pass.

## Merge request

This is ready for maintainer review and merge. Maintainer edits are enabled.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/tokenmaxxing/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787862153&installation_model_id=428386&pr_number=58&repository=851-labs%2Ftokenmaxxing&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Ftokenmaxxing%2Fpull%2F58&signature=dc64eacba37286749b233a14b7ac1009c2319e845c4640883114d655dfd80b51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->