### PR TITLE
fix: require ccusage replay correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to tokenmaxxing are documented here. Versions are anchored t
 
 ## Unreleased
 
+### Fixed
+
+- Required ccusage 20.0.19 or newer to prevent replayed Codex subagent history from inflating usage totals.
+
 ## 0.5.0 - 2026-07-22
 
 ### Added

--- a/apps/api/src/usage/ccusage.test.ts
+++ b/apps/api/src/usage/ccusage.test.ts
@@ -9,7 +9,7 @@ describe("parseRawUsageReports", () => {
     const reports: RawUsageReportInput[] = [
       {
         command: [
-          "ccusage@^20.0.17",
+          "ccusage@^20.0.19",
           "codex",
           "daily",
           "--json",

--- a/apps/cli/src/ccusage/runner.test.ts
+++ b/apps/cli/src/ccusage/runner.test.ts
@@ -30,9 +30,9 @@ async function ccusageErrorFor<A>(effect: Effect.Effect<A, CcusageRunError>) {
 }
 
 describe("ccusage commands", () => {
-  it("uses the minimum v20 release verified for GPT-5.6", () => {
+  it("uses the minimum v20 release with the Codex replay fix", () => {
     expect(dailyCcusageCommand(codex)).toEqual([
-      "ccusage@^20.0.17",
+      "ccusage@^20.0.19",
       "codex",
       "daily",
       "--json",
@@ -41,7 +41,7 @@ describe("ccusage commands", () => {
       "calculate",
     ]);
     expect(sessionCcusageCommand(codex)).toEqual([
-      "ccusage@^20.0.17",
+      "ccusage@^20.0.19",
       "codex",
       "session",
       "--json",
@@ -52,7 +52,7 @@ describe("ccusage commands", () => {
 
   it("builds focused Pi daily and session commands", () => {
     expect(dailyCcusageCommand(pi)).toEqual([
-      "ccusage@^20.0.17",
+      "ccusage@^20.0.19",
       "pi",
       "daily",
       "--json",
@@ -61,7 +61,7 @@ describe("ccusage commands", () => {
       "calculate",
     ]);
     expect(sessionCcusageCommand(pi)).toEqual([
-      "ccusage@^20.0.17",
+      "ccusage@^20.0.19",
       "pi",
       "session",
       "--json",
@@ -74,15 +74,15 @@ describe("ccusage commands", () => {
 describe("ccusageCommandInvocations", () => {
   it("selects the Windows npm command shim", () => {
     expect(ccusageCommandInvocations(["codex", "daily"], "win32")).toEqual([
-      { args: ["x", "ccusage@^20.0.17", "codex", "daily"], command: "bun" },
-      { args: ["-y", "ccusage@^20.0.17", "codex", "daily"], command: "npx.cmd" },
+      { args: ["x", "ccusage@^20.0.19", "codex", "daily"], command: "bun" },
+      { args: ["-y", "ccusage@^20.0.19", "codex", "daily"], command: "npx.cmd" },
     ]);
   });
 
   it("keeps the POSIX npm fallback", () => {
     expect(ccusageCommandInvocations(["codex", "daily"], "linux")).toEqual([
-      { args: ["x", "ccusage@^20.0.17", "codex", "daily"], command: "bun" },
-      { args: ["-y", "ccusage@^20.0.17", "codex", "daily"], command: "npx" },
+      { args: ["x", "ccusage@^20.0.19", "codex", "daily"], command: "bun" },
+      { args: ["-y", "ccusage@^20.0.19", "codex", "daily"], command: "npx" },
     ]);
   });
 });
@@ -97,7 +97,7 @@ describe("execCcusage", () => {
       ),
     ).resolves.toBe('{"daily":[]}');
     expect(run).toHaveBeenCalledOnce();
-    expect(run).toHaveBeenCalledWith("bun", ["x", "ccusage@^20.0.17", "codex", "daily"]);
+    expect(run).toHaveBeenCalledWith("bun", ["x", "ccusage@^20.0.19", "codex", "daily"]);
   });
 
   it("falls back to npx.cmd when Bun is missing on Windows", async () => {
@@ -117,8 +117,8 @@ describe("execCcusage", () => {
         execCcusage(["codex", "daily"], "codex", "daily", { platform: "win32", run }),
       ),
     ).resolves.toBe('{"daily":[]}');
-    expect(run).toHaveBeenNthCalledWith(1, "bun", ["x", "ccusage@^20.0.17", "codex", "daily"]);
-    expect(run).toHaveBeenNthCalledWith(2, "npx.cmd", ["-y", "ccusage@^20.0.17", "codex", "daily"]);
+    expect(run).toHaveBeenNthCalledWith(1, "bun", ["x", "ccusage@^20.0.19", "codex", "daily"]);
+    expect(run).toHaveBeenNthCalledWith(2, "npx.cmd", ["-y", "ccusage@^20.0.19", "codex", "daily"]);
   });
 
   it("does not mask a Bun execution failure with the npm fallback", async () => {

--- a/apps/cli/src/ccusage/runner.ts
+++ b/apps/cli/src/ccusage/runner.ts
@@ -7,12 +7,12 @@ import { decodeDailyReport, decodeSessionReport } from "./schema";
 import type { CcusageSource } from "./sources";
 
 /**
- * Shells out to `bun x ccusage@^20.0.17 <source> daily --json --breakdown` (npx
+ * Shells out to `bun x ccusage@^20.0.19 <source> daily --json --breakdown` (npx
  * fallback only when bun itself is missing). Runner and report failures stay
  * typed so the sync layer can distinguish them from valid empty reports.
  */
 
-const CCUSAGE_SPEC = "ccusage@^20.0.17";
+const CCUSAGE_SPEC = "ccusage@^20.0.19";
 const RUN_TIMEOUT_MS = 180_000;
 
 class CcusageRunError extends Data.TaggedError("CcusageRunError")<{


### PR DESCRIPTION
## Summary

- raise the ccusage v20 floor from 20.0.17 to 20.0.19
- update runner and raw-report fixtures to record the corrected minimum
- document the Codex replay-accounting correction in the changelog

## Why

ccusage 20.0.19 includes the structural Codex fork/subagent replay deduplication and the follow-up fix for replay bursts that cross a second boundary. Keeping 20.0.17 as the declared minimum allowed known-corrupt accounting implementations even though a fresh online resolution currently selects the latest v20 release.

Refs #56.

## Validation

- `bun run fmt`
- `bun run lint` (one pre-existing warning in `apps/api/src/leaderboard/service.test.ts`)
- `bun run typecheck` (5/5 workspaces)
- `bun run test` (359 tests)
- `bun x 'ccusage@^20.0.19' --version` → `ccusage 20.0.19`
