### PR TITLE
fix: backfill corrected Codex usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to tokenmaxxing are documented here. Versions are anchored t
 ### Fixed
 
 - Required ccusage 20.0.19 or newer to prevent replayed Codex subagent history from inflating usage totals.
+- Treat successful raw daily reports as authoritative device/day/source slices so corrected
+  backfills remove stale model rows, and run one full Codex replay after service upgrades.
 
 ## 0.5.0 - 2026-07-22
 

--- a/apps/api/src/usage/ccusage.test.ts
+++ b/apps/api/src/usage/ccusage.test.ts
@@ -40,6 +40,7 @@ describe("parseRawUsageReports", () => {
 
     const result = await Effect.runPromise(parseRawUsageReports(reports));
 
+    expect(result.coveredDays).toEqual([{ date: "2026-07-11", source: "codex" }]);
     expect(result.persistableReports).toEqual(reports);
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0]).toMatchObject({
@@ -92,6 +93,7 @@ describe("parseRawUsageReports", () => {
         source: "claude",
       },
     ]);
+    expect(result.coveredDays).toEqual([{ date: "2026-07-22", source: "claude" }]);
     expect(result.sourceStats).toEqual([{ sessionCount: 1, source: "claude" }]);
     expect(JSON.stringify(result.persistableReports)).not.toContain("secret-client");
   });
@@ -108,6 +110,11 @@ describe("parseRawUsageReports", () => {
       ]),
     );
 
-    expect(result).toEqual({ persistableReports: [], rows: [], sourceStats: [] });
+    expect(result).toEqual({
+      coveredDays: [],
+      persistableReports: [],
+      rows: [],
+      sourceStats: [],
+    });
   });
 });

--- a/apps/api/src/usage/ccusage.ts
+++ b/apps/api/src/usage/ccusage.ts
@@ -56,9 +56,15 @@ const decodeDailyReport = Schema.decodeUnknownEffect(CcusageDailyReport);
 const decodeSessionReport = Schema.decodeUnknownEffect(CcusageSessionReport);
 
 interface ParsedRawUsageReports {
+  coveredDays: CoveredUsageDay[];
   persistableReports: PersistableDailyReport[];
   rows: UsageDayInput[];
   sourceStats: SourceUsageStatsInput[];
+}
+
+interface CoveredUsageDay {
+  date: string;
+  source: string;
 }
 
 type PersistableDailyReport = Omit<RawUsageReportInput, "reportKind"> & {
@@ -69,6 +75,7 @@ function parseRawUsageReports(
   reports: readonly RawUsageReportInput[],
 ): Effect.Effect<ParsedRawUsageReports> {
   return Effect.gen(function* () {
+    const coveredDays = new Map<string, CoveredUsageDay>();
     const persistableReports: PersistableDailyReport[] = [];
     const rows: UsageDayInput[] = [];
     const sourceStats: SourceUsageStatsInput[] = [];
@@ -83,6 +90,12 @@ function parseRawUsageReports(
             reportKind: "daily",
             source: report.source,
           });
+          for (const day of decoded.value.daily) {
+            coveredDays.set(JSON.stringify([report.source, day.date]), {
+              date: day.date,
+              source: report.source,
+            });
+          }
           rows.push(...aggregateDays(report.source, decoded.value.daily));
         }
       } else {
@@ -96,7 +109,7 @@ function parseRawUsageReports(
       }
     }
 
-    return { persistableReports, rows, sourceStats };
+    return { coveredDays: [...coveredDays.values()], persistableReports, rows, sourceStats };
   });
 }
 
@@ -213,4 +226,4 @@ function collectModelEntries(day: CcusageDay): ModelTotals[] {
 
 export { parseRawUsageReports, PARSER_VERSION };
 
-export type { PersistableDailyReport };
+export type { CoveredUsageDay, PersistableDailyReport };

--- a/apps/api/src/usage/d1.test.ts
+++ b/apps/api/src/usage/d1.test.ts
@@ -1,0 +1,181 @@
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { Effect, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Drizzle } from "../database";
+import { UsageRepositoryLive } from "./d1";
+import { RawUsageObjectStore } from "./raw-store";
+import { UsageRepository } from "./service";
+
+describe("D1 usage replacement", () => {
+  let sqlite: DatabaseSync;
+
+  beforeEach(() => {
+    sqlite = new DatabaseSync(":memory:");
+    sqlite.exec(`
+      create table usage_days (
+        device_id text not null,
+        user_id text not null,
+        date text not null,
+        source text not null,
+        model text not null,
+        input_tokens integer not null default 0,
+        output_tokens integer not null default 0,
+        cache_creation_tokens integer not null default 0,
+        cache_read_tokens integer not null default 0,
+        total_tokens integer not null default 0,
+        cost_usd real not null default 0,
+        synced_at integer not null,
+        primary key (device_id, date, source, model)
+      );
+    `);
+  });
+
+  afterEach(() => sqlite.close());
+
+  it("prunes only older models omitted from covered device/day/source slices", async () => {
+    const insertUsage = sqlite.prepare(
+      `insert into usage_days (
+        device_id, user_id, date, source, model, synced_at
+      ) values (?, 'user', ?, ?, ?, ?)`,
+    );
+    insertUsage.run("device", "2026-07-21", "codex", "keep", 500);
+    insertUsage.run("device", "2026-07-21", "codex", "stale", 500);
+    insertUsage.run("device", "2026-07-21", "codex", "newer", 1_500);
+    insertUsage.run("device", "2026-07-21", "claude", "other-source", 500);
+    insertUsage.run("device", "2026-07-20", "codex", "other-date", 500);
+    insertUsage.run("other-device", "2026-07-21", "codex", "other-device", 500);
+
+    const repository = await makeRepository(sqlite);
+    await run(
+      repository.pruneChunk(
+        "device",
+        [{ date: "2026-07-21", models: ["keep"], source: "codex" }],
+        new Date(1_000),
+      ),
+    );
+
+    expect(
+      sqlite
+        .prepare(
+          `select device_id, date, source, model
+           from usage_days
+           order by device_id, date, source, model`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        date: "2026-07-20",
+        device_id: "device",
+        model: "other-date",
+        source: "codex",
+      },
+      {
+        date: "2026-07-21",
+        device_id: "device",
+        model: "other-source",
+        source: "claude",
+      },
+      {
+        date: "2026-07-21",
+        device_id: "device",
+        model: "keep",
+        source: "codex",
+      },
+      {
+        date: "2026-07-21",
+        device_id: "device",
+        model: "newer",
+        source: "codex",
+      },
+      {
+        date: "2026-07-21",
+        device_id: "other-device",
+        model: "other-device",
+        source: "codex",
+      },
+    ]);
+  });
+
+  it("removes all older rows when a covered slice contains no models", async () => {
+    sqlite.exec(`
+      insert into usage_days (
+        device_id, user_id, date, source, model, synced_at
+      ) values
+        ('device', 'user', '2026-07-21', 'codex', 'stale-a', 500),
+        ('device', 'user', '2026-07-21', 'codex', 'stale-b', 500);
+    `);
+
+    const repository = await makeRepository(sqlite);
+    await run(
+      repository.pruneChunk(
+        "device",
+        [{ date: "2026-07-21", models: [], source: "codex" }],
+        new Date(1_000),
+      ),
+    );
+
+    expect(sqlite.prepare("select model from usage_days").all()).toEqual([]);
+  });
+});
+
+async function makeRepository(sqlite: DatabaseSync) {
+  const drizzleLayer = Drizzle.layer({ raw: Effect.succeed(d1Database(sqlite)) });
+  const rawStoreLayer = Layer.succeed(
+    RawUsageObjectStore,
+    RawUsageObjectStore.of({
+      putObject: () => Effect.succeed(undefined),
+    }),
+  );
+
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* UsageRepository;
+    }).pipe(
+      Effect.provide(
+        UsageRepositoryLive.pipe(Layer.provide(Layer.merge(drizzleLayer, rawStoreLayer))),
+      ),
+    ),
+  );
+}
+
+function run<A, E>(effect: Effect.Effect<A, E, any>): Promise<A> {
+  return Effect.runPromise(effect as Effect.Effect<A, E, never>);
+}
+
+function d1Database(sqlite: DatabaseSync): D1Database {
+  return {
+    batch: async (statements: D1PreparedStatement[]) => {
+      sqlite.exec("begin");
+      try {
+        const results = [];
+        for (const statement of statements) {
+          results.push(await statement.all());
+        }
+        sqlite.exec("commit");
+        return results;
+      } catch (error) {
+        sqlite.exec("rollback");
+        throw error;
+      }
+    },
+    prepare: (query: string) => d1Statement(sqlite, query),
+  } as unknown as D1Database;
+}
+
+function d1Statement(
+  sqlite: DatabaseSync,
+  query: string,
+  parameters: SQLInputValue[] = [],
+): D1PreparedStatement {
+  return {
+    all: async () => ({ results: sqlite.prepare(query).all(...parameters) }),
+    bind: (...values: unknown[]) => d1Statement(sqlite, query, values as SQLInputValue[]),
+    raw: async () => {
+      const statement = sqlite.prepare(query);
+      statement.setReturnArrays(true);
+      return statement.all(...parameters);
+    },
+    run: async () => sqlite.prepare(query).run(...parameters),
+  } as unknown as D1PreparedStatement;
+}

--- a/apps/api/src/usage/d1.ts
+++ b/apps/api/src/usage/d1.ts
@@ -1,5 +1,5 @@
 import { devices, usageDays, usageRawBatches, usageSourceStats } from "@tokenmaxxing/db";
-import { eq } from "drizzle-orm";
+import { and, eq, lt, notInArray } from "drizzle-orm";
 import { Effect } from "effect";
 import { Layer } from "effect";
 
@@ -91,6 +91,33 @@ const makeD1UsageRepository = Effect.fn("makeD1UsageRepository")(function* () {
                   syncedAt,
                 },
               }),
+          );
+          const [first, ...rest] = statements;
+
+          return db.batch([first!, ...rest]);
+        });
+      }),
+    pruneChunk: (deviceId, scopes, syncedAt) =>
+      Effect.gen(function* () {
+        if (scopes.length === 0) {
+          return;
+        }
+
+        yield* database.use((db) => {
+          const statements = scopes.map((scope) =>
+            db
+              .delete(usageDays)
+              .where(
+                and(
+                  eq(usageDays.deviceId, deviceId),
+                  eq(usageDays.date, scope.date),
+                  eq(usageDays.source, scope.source),
+                  lt(usageDays.syncedAt, syncedAt),
+                  ...(scope.models.length === 0
+                    ? []
+                    : [notInArray(usageDays.model, [...scope.models])]),
+                ),
+              ),
           );
           const [first, ...rest] = statements;
 

--- a/apps/api/src/usage/service.test.ts
+++ b/apps/api/src/usage/service.test.ts
@@ -107,6 +107,7 @@ interface RepositoryOptions {
 
 function makeRepository(options: RepositoryOptions = {}) {
   const checkInDevice = vi.fn(() => Effect.succeed(undefined));
+  const pruneChunk = vi.fn(() => Effect.succeed(undefined));
   const upsertChunk = vi.fn(() => Effect.succeed(undefined));
   const touchDevice = vi.fn(() => Effect.succeed(undefined));
   const upsertSourceStats = vi.fn(() => Effect.succeed(undefined));
@@ -118,6 +119,7 @@ function makeRepository(options: RepositoryOptions = {}) {
 
   const repository: UsageRepositoryShape = {
     checkInDevice,
+    pruneChunk,
     touchDevice,
     upsertChunk,
     upsertRawReports,
@@ -126,6 +128,7 @@ function makeRepository(options: RepositoryOptions = {}) {
 
   return {
     checkInDevice,
+    pruneChunk,
     repository,
     touchDevice,
     upsertChunk,
@@ -142,7 +145,7 @@ async function makeService(repository: UsageRepositoryShape) {
 
 describe("UsageService.checkIn", () => {
   it("touches service telemetry without writing usage rows", async () => {
-    const { checkInDevice, repository, touchDevice, upsertChunk, upsertSourceStats } =
+    const { checkInDevice, pruneChunk, repository, touchDevice, upsertChunk, upsertSourceStats } =
       makeRepository();
     const service = await makeService(repository);
 
@@ -194,6 +197,7 @@ describe("UsageService.checkIn", () => {
       expect.any(Date),
     );
     expect(upsertChunk).not.toHaveBeenCalled();
+    expect(pruneChunk).not.toHaveBeenCalled();
     expect(upsertSourceStats).not.toHaveBeenCalled();
     expect(touchDevice).not.toHaveBeenCalled();
   });
@@ -216,7 +220,8 @@ describe("UsageService.checkIn", () => {
 
 describe("UsageService.syncBatch", () => {
   it("upserts daily rows, source stats, and touches the device", async () => {
-    const { repository, touchDevice, upsertChunk, upsertSourceStats } = makeRepository();
+    const { pruneChunk, repository, touchDevice, upsertChunk, upsertSourceStats } =
+      makeRepository();
     const service = await makeService(repository);
 
     const result = await Effect.runPromise(
@@ -236,6 +241,7 @@ describe("UsageService.syncBatch", () => {
       [usageDay],
       expect.any(Date),
     );
+    expect(pruneChunk).not.toHaveBeenCalled();
     expect(upsertSourceStats).toHaveBeenCalledWith(
       "user_123",
       "device_123",
@@ -288,7 +294,8 @@ describe("UsageService.syncBatch", () => {
   });
 
   it("does not touch storage when the token has no device", async () => {
-    const { repository, touchDevice, upsertChunk, upsertSourceStats } = makeRepository();
+    const { pruneChunk, repository, touchDevice, upsertChunk, upsertSourceStats } =
+      makeRepository();
     const service = await makeService(repository);
 
     await expect(
@@ -298,6 +305,7 @@ describe("UsageService.syncBatch", () => {
     ).rejects.toBeInstanceOf(DeviceMissing);
 
     expect(upsertChunk).not.toHaveBeenCalled();
+    expect(pruneChunk).not.toHaveBeenCalled();
     expect(upsertSourceStats).not.toHaveBeenCalled();
     expect(touchDevice).not.toHaveBeenCalled();
   });
@@ -305,8 +313,14 @@ describe("UsageService.syncBatch", () => {
 
 describe("UsageService.ingestRaw", () => {
   it("stores normalized daily reports and derives legacy session counts without persisting them", async () => {
-    const { repository, touchDevice, upsertChunk, upsertRawReports, upsertSourceStats } =
-      makeRepository();
+    const {
+      pruneChunk,
+      repository,
+      touchDevice,
+      upsertChunk,
+      upsertRawReports,
+      upsertSourceStats,
+    } = makeRepository();
     const service = await makeService(repository);
 
     const result = await Effect.runPromise(
@@ -340,6 +354,11 @@ describe("UsageService.ingestRaw", () => {
       [usageDay],
       expect.any(Date),
     );
+    expect(pruneChunk).toHaveBeenCalledWith(
+      "device_123",
+      [{ date: "2026-06-15", models: ["GPT-5.5"], source: "codex" }],
+      expect.any(Date),
+    );
     expect(upsertSourceStats).toHaveBeenCalledWith(
       "user_123",
       "device_123",
@@ -349,6 +368,12 @@ describe("UsageService.ingestRaw", () => {
     expect(touchDevice).toHaveBeenCalledWith("device_123", device, expect.any(Date));
     expect(upsertRawReports.mock.invocationCallOrder[0]).toBeLessThan(
       upsertChunk.mock.invocationCallOrder[0]!,
+    );
+    expect(upsertChunk.mock.invocationCallOrder[0]).toBeLessThan(
+      pruneChunk.mock.invocationCallOrder[0]!,
+    );
+    expect(pruneChunk.mock.invocationCallOrder[0]).toBeLessThan(
+      upsertSourceStats.mock.invocationCallOrder[0]!,
     );
   });
 
@@ -382,8 +407,14 @@ describe("UsageService.ingestRaw", () => {
 
   it("does not write structured rows when raw persistence fails", async () => {
     const rawReportsError = new RawUsageStorageError({ cause: "r2 down" });
-    const { repository, touchDevice, upsertChunk, upsertRawReports, upsertSourceStats } =
-      makeRepository({ rawReportsError });
+    const {
+      pruneChunk,
+      repository,
+      touchDevice,
+      upsertChunk,
+      upsertRawReports,
+      upsertSourceStats,
+    } = makeRepository({ rawReportsError });
     const service = await makeService(repository);
 
     await expect(
@@ -398,6 +429,7 @@ describe("UsageService.ingestRaw", () => {
 
     expect(upsertRawReports).toHaveBeenCalled();
     expect(upsertChunk).not.toHaveBeenCalled();
+    expect(pruneChunk).not.toHaveBeenCalled();
     expect(upsertSourceStats).not.toHaveBeenCalled();
     expect(touchDevice).not.toHaveBeenCalled();
   });

--- a/apps/api/src/usage/service.ts
+++ b/apps/api/src/usage/service.ts
@@ -17,7 +17,12 @@ import type {
 
 import { sha256Hex } from "../auth/crypto";
 import type { DatabaseError } from "../database";
-import { parseRawUsageReports, PARSER_VERSION, type PersistableDailyReport } from "./ccusage";
+import {
+  parseRawUsageReports,
+  PARSER_VERSION,
+  type CoveredUsageDay,
+  type PersistableDailyReport,
+} from "./ccusage";
 import { normalizeUsageDays } from "./models";
 import type { RawUsageStorageError } from "./raw-store";
 
@@ -105,6 +110,12 @@ interface UsageServiceAutoUpdate {
   status: ServiceAutoUpdateStatusValue;
 }
 
+interface UsageReplacementScope {
+  date: string;
+  models: readonly string[];
+  source: string;
+}
+
 interface UsageRepositoryShape {
   checkInDevice(
     deviceId: string,
@@ -117,6 +128,12 @@ interface UsageRepositoryShape {
     userId: string,
     deviceId: string,
     rows: readonly UsageDayInput[],
+    syncedAt: Date,
+  ): Effect.Effect<void, DatabaseError, any>;
+  /** Removes models omitted by an authoritative raw daily report. */
+  pruneChunk(
+    deviceId: string,
+    scopes: readonly UsageReplacementScope[],
     syncedAt: Date,
   ): Effect.Effect<void, DatabaseError, any>;
   touchDevice(
@@ -189,6 +206,7 @@ const makeUsageService = Effect.fn("makeUsageService")(function* () {
         parsed.rows,
         mergeSourceStats(parsed.sourceStats, sourceStats),
         syncedAt,
+        parsed.coveredDays,
       );
 
       return {
@@ -320,6 +338,7 @@ function writeStructuredUsage(
   days: readonly UsageDayInput[],
   sourceStats: readonly SourceUsageStatsInput[],
   syncedAt: Date,
+  coveredDays: readonly CoveredUsageDay[] = [],
 ) {
   return Effect.gen(function* () {
     const normalizedDays = normalizeUsageDays(days);
@@ -333,6 +352,12 @@ function writeStructuredUsage(
         )
         .pipe(Effect.orDie);
     }
+    const replacementScopes = buildReplacementScopes(coveredDays, normalizedDays);
+    for (let offset = 0; offset < replacementScopes.length; offset += UPSERT_CHUNK_SIZE) {
+      yield* repository
+        .pruneChunk(deviceId, replacementScopes.slice(offset, offset + UPSERT_CHUNK_SIZE), syncedAt)
+        .pipe(Effect.orDie);
+    }
     yield* repository.upsertSourceStats(userId, deviceId, sourceStats, syncedAt).pipe(Effect.orDie);
     yield* repository.touchDevice(deviceId, device, syncedAt).pipe(Effect.orDie);
 
@@ -340,8 +365,37 @@ function writeStructuredUsage(
   });
 }
 
+function buildReplacementScopes(
+  coveredDays: readonly CoveredUsageDay[],
+  normalizedDays: readonly UsageDayInput[],
+): UsageReplacementScope[] {
+  const scopes = new Map<string, { date: string; models: Set<string>; source: string }>();
+  for (const coveredDay of coveredDays) {
+    scopes.set(JSON.stringify([coveredDay.date, coveredDay.source]), {
+      date: coveredDay.date,
+      models: new Set(),
+      source: coveredDay.source,
+    });
+  }
+  for (const day of normalizedDays) {
+    scopes.get(JSON.stringify([day.date, day.source]))?.models.add(day.model);
+  }
+
+  return [...scopes.values()].map((scope) => ({
+    date: scope.date,
+    models: [...scope.models].sort(),
+    source: scope.source,
+  }));
+}
+
 const textEncoder = new TextEncoder();
 
 export { makeUsageService, UsageRepository, UsageService };
 
-export type { StoredRawUsageReport, SyncResult, UsageRepositoryShape, UsageServiceCheckIn };
+export type {
+  StoredRawUsageReport,
+  SyncResult,
+  UsageReplacementScope,
+  UsageRepositoryShape,
+  UsageServiceCheckIn,
+};

--- a/apps/cli/src/commands/service.test.ts
+++ b/apps/cli/src/commands/service.test.ts
@@ -53,6 +53,8 @@ import {
   serviceRunnerReleaseChannel,
   serviceRunnerReleaseIsNewer,
   serviceRunnerTarget,
+  serviceCompletedUsageReplacementBackfill,
+  serviceNeedsUsageReplacementBackfill,
   serviceScheduledSyncSince,
   serviceInstallProgram,
   serviceLockStatus,
@@ -1390,6 +1392,60 @@ describe("serviceScheduledSyncSince", () => {
   });
 });
 
+describe("usage replacement backfill", () => {
+  it("runs once on a scheduled service after upgrading", () => {
+    expect(serviceNeedsUsageReplacementBackfill({ version: 1 }, true)).toBe(true);
+    expect(
+      serviceNeedsUsageReplacementBackfill(
+        { usageReplacementBackfillVersion: 1, version: 1 },
+        true,
+      ),
+    ).toBe(false);
+    expect(serviceNeedsUsageReplacementBackfill({ version: 1 }, false)).toBe(false);
+  });
+
+  it("completes after Codex daily collection succeeds or finds no local data", () => {
+    expect(
+      serviceCompletedUsageReplacementBackfill({
+        dryRun: false,
+        rows: 1,
+        sourceResults: [
+          {
+            source: "codex",
+            status: "synced",
+            summary: { days: 1, models: 1, rows: 1, sessions: 1, spendUsd: 1 },
+          },
+        ],
+        sources: {
+          codex: { days: 1, models: 1, rows: 1, sessions: 1, spendUsd: 1 },
+        },
+        status: "ok",
+        upserted: 1,
+      }),
+    ).toBe(true);
+    expect(
+      serviceCompletedUsageReplacementBackfill({
+        dryRun: false,
+        rows: 0,
+        sourceResults: [
+          {
+            issue: {
+              code: "command_failed",
+              message: "ccusage command failed",
+              report: "daily",
+            },
+            source: "codex",
+            status: "failed",
+            summary: null,
+          },
+        ],
+        sources: { codex: null },
+        status: "error",
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("service run state", () => {
   const syncResult: SyncResult = {
     dryRun: false,
@@ -1424,6 +1480,7 @@ describe("service run state", () => {
         result: syncResult,
         since: "2026-06-16",
         successAt: "2026-06-16T10:00:01.000Z",
+        usageReplacementBackfillVersion: 1,
         version: "0.4.12",
       },
     );
@@ -1444,6 +1501,7 @@ describe("service run state", () => {
       lastSuccessAt: "2026-06-16T10:00:01.000Z",
       lastSyncStatus: "ok",
       lastUpserted: 40,
+      usageReplacementBackfillVersion: 1,
       version: 1,
     });
     expect(state.lastSources).toEqual([

--- a/apps/cli/src/commands/service.ts
+++ b/apps/cli/src/commands/service.ts
@@ -80,6 +80,7 @@ const SERVICE_PACKAGE_UPDATE_TIMEOUT_MS = 4 * 60 * 1000;
 const SERVICE_VERSION_TIMEOUT_MS = 30 * 1000;
 const SERVICE_LOG_MAX_BYTES = 5 * 1024 * 1024;
 const SERVICE_LOG_ROTATIONS = 3;
+const USAGE_REPLACEMENT_BACKFILL_VERSION = 1;
 const NPM_LATEST_URL = "https://registry.npmjs.org/@851-labs%2Ftokenmaxxing/latest";
 const SERVICE_UPLOAD_RETRY_POLICY: UploadRetryPolicy = {
   attempts: 3,
@@ -244,6 +245,7 @@ interface ServiceState {
   lastSuccessDate?: string;
   lastUpserted?: number;
   reloadRequired?: boolean;
+  usageReplacementBackfillVersion?: number;
   version: 1;
 }
 
@@ -1185,7 +1187,13 @@ function runServiceSyncOnce(paths: ServicePaths, options: ServiceRunOptions) {
     const startedAtMs = startedAt.getTime();
     const cliVersion = packageJson.version;
     const cliArch = arch();
-    const scheduledSince = serviceScheduledSyncSince(currentState, startedAt, options.scheduled);
+    const usageReplacementBackfill = serviceNeedsUsageReplacementBackfill(
+      currentState,
+      options.scheduled,
+    );
+    const scheduledSince = usageReplacementBackfill
+      ? undefined
+      : serviceScheduledSyncSince(currentState, startedAt, options.scheduled);
     const metadata = yield* readServiceMetadata(paths.metadataPath);
     const nativeStatus = yield* readNativeSchedulerStatus(paths);
     const reloadRequired = serviceReloadRequired(metadata, currentState);
@@ -1269,6 +1277,7 @@ function runServiceSyncOnce(paths: ServicePaths, options: ServiceRunOptions) {
       json: true,
       silent: true,
       ...(scheduledSince === undefined ? {} : { since: scheduledSince }),
+      ...(usageReplacementBackfill ? { sources: "codex" } : {}),
       ...(options.scheduled ? { uploadPolicy: SERVICE_UPLOAD_RETRY_POLICY } : {}),
     }).pipe(
       Effect.match({
@@ -1323,6 +1332,10 @@ function runServiceSyncOnce(paths: ServicePaths, options: ServiceRunOptions) {
       schedulerActive: nativeStatus.active,
       since: scheduledSince,
       successAt,
+      usageReplacementBackfillVersion:
+        usageReplacementBackfill && serviceCompletedUsageReplacementBackfill(result.value)
+          ? USAGE_REPLACEMENT_BACKFILL_VERSION
+          : undefined,
       version: cliVersion,
     });
     const repairReport = yield* maybeScheduleDeferredServiceRepair({
@@ -1827,6 +1840,7 @@ function serviceRunSuccessState(
     schedulerActive?: boolean | undefined;
     since?: string | undefined;
     successAt: string;
+    usageReplacementBackfillVersion?: number | undefined;
     version: string;
   },
 ): ServiceState {
@@ -1847,6 +1861,9 @@ function serviceRunSuccessState(
     lastSyncStatus: input.result.status,
     lastUpserted: input.result.upserted ?? 0,
     reloadRequired: input.reloadRequired,
+    ...(input.usageReplacementBackfillVersion === undefined
+      ? {}
+      : { usageReplacementBackfillVersion: input.usageReplacementBackfillVersion }),
     version: 1,
   };
 }
@@ -1991,6 +2008,18 @@ function serviceScheduledSyncSince(
   }
 
   return previousLocalDateKey(now);
+}
+
+function serviceNeedsUsageReplacementBackfill(state: ServiceState, scheduled: boolean): boolean {
+  return (
+    scheduled && (state.usageReplacementBackfillVersion ?? 0) < USAGE_REPLACEMENT_BACKFILL_VERSION
+  );
+}
+
+function serviceCompletedUsageReplacementBackfill(result: SyncResult): boolean {
+  return result.sourceResults.some(
+    (source) => source.source === "codex" && source.status !== "failed",
+  );
 }
 
 function localDateKey(date: Date): string {
@@ -2250,6 +2279,9 @@ function serviceStateJson(state: ServiceState): Partial<ServiceState> {
     ...(state.lastSuccessAt === undefined ? {} : { lastSuccessAt: state.lastSuccessAt }),
     ...(state.lastUpserted === undefined ? {} : { lastUpserted: state.lastUpserted }),
     ...(state.reloadRequired === undefined ? {} : { reloadRequired: state.reloadRequired }),
+    ...(state.usageReplacementBackfillVersion === undefined
+      ? {}
+      : { usageReplacementBackfillVersion: state.usageReplacementBackfillVersion }),
     version: state.version,
   };
 }
@@ -4473,6 +4505,8 @@ export {
   serviceRunnerReleaseIsNewer,
   serviceRunnerTarget,
   serviceRunnerTargetCandidates,
+  serviceCompletedUsageReplacementBackfill,
+  serviceNeedsUsageReplacementBackfill,
   serviceScheduledSyncSince,
   serviceCommand,
   serviceInstallProgram,


### PR DESCRIPTION
## Summary

- treat each valid raw daily report as authoritative for its covered device/date/source slices
- upsert corrected rows before pruning stale models, while protecting newer concurrent writes
- run one full Codex replay once per upgraded background service and retry until daily collection/upload succeeds
- keep legacy structured syncs upsert-only

## Validation

- `bun run fmt`
- `bun run lint` (one pre-existing warning in `apps/api/src/leaderboard/service.test.ts`)
- `bun run typecheck`
- `bun run test` (349 tests)

Refs #56