### PR TITLE
feat(cli): add Hermes agent source

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Sync is idempotent and profiles aggregate across devices, so you can run
 - OpenCode
 - Gemini CLI
 - GitHub Copilot CLI
+- Hermes
 - Pi
 
 ## Usage

--- a/apps/cli/src/ccusage/sources.test.ts
+++ b/apps/cli/src/ccusage/sources.test.ts
@@ -17,6 +17,13 @@ describe("resolveSources", () => {
     });
   });
 
+  it("resolves Hermes to the focused ccusage subcommand", () => {
+    expect(resolveSources(["hermes"])).toEqual({
+      invalid: [],
+      sources: [{ source: "hermes", subcommand: "hermes" }],
+    });
+  });
+
   it("rejects unknown sources", () => {
     expect(resolveSources(["bogus"]).invalid).toEqual(["bogus"]);
   });

--- a/apps/cli/src/ccusage/sources.ts
+++ b/apps/cli/src/ccusage/sources.ts
@@ -18,6 +18,7 @@ const CCUSAGE_SOURCES: readonly CcusageSource[] = [
   { source: "opencode", subcommand: "opencode" },
   { source: "gemini", subcommand: "gemini" },
   { source: "copilot", subcommand: "copilot" },
+  { source: "hermes", subcommand: "hermes" },
   { source: "pi", subcommand: "pi" },
 ];
 


### PR DESCRIPTION
## Summary

ccusage v20 already ships a focused `hermes` subcommand (`ccusage hermes daily`), but tokenmaxxing's `CCUSAGE_SOURCES` list never registered it — so Hermes usage was never synced, and `--sources hermes` was rejected as an unknown source.

This PR adds Hermes as a first-class agent source.

## Changes

- **`apps/cli/src/ccusage/sources.ts`** — register `{ source: "hermes", subcommand: "hermes" }` in `CCUSAGE_SOURCES`. Hermes now syncs by default and is valid for `--sources hermes`.
- **`apps/cli/src/ccusage/sources.test.ts`** — test that `resolveSources(["hermes"])` maps to the focused ccusage subcommand.
- **`README.md`** — add Hermes to the supported agents list.

## Why no aggregator changes

The aggregator (`aggregate.ts`) already handles every ccusage dialect generically — `modelBreakdowns` (claude-style), `models` record (codex-style), or `modelsUsed` fallback. Hermes' ccusage output fits one of these paths, so no transform changes are needed.

## Verification

- `bunx vitest run src/ccusage/sources.test.ts` — 4/4 pass (including the new Hermes test)
- Lefthook pre-commit hook ran fmt, typecheck, lint, test — all green

## Context

- ccusage Hermes docs: https://ccusage.com/guide/hermes/
- ccusage requires `HERMES_HOME="$HOME/.hermes"` to locate Hermes data

---

Draft — happy to address any naming/labeling preferences before marking ready for review.