### PR TITLE
feat: add composite profile favicons

### DIFF
--- a/apps/www/src/lib/favicon-svg.ts
+++ b/apps/www/src/lib/favicon-svg.ts
@@ -1,0 +1,105 @@
+const FAVICON_LAYOUT = {
+  avatar: { size: 24, x: 32, y: 32 },
+  canvasSize: 64,
+  gradient: { radius: 5, size: 40, x: 12, y: 12 },
+} as const;
+
+const DEFAULT_FAVICON_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
+const PROFILE_FAVICON_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=3600";
+const MAX_AVATAR_BYTES = 1_000_000;
+const SUPPORTED_AVATAR_TYPES = new Set([
+  "image/avif",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+const GRADIENT_PNG_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAQeElEQVR42pVbbbbrxo2sQjcl2fEGZ6+zg+xg1uETj+9lo/ID6C+Kui9JDk1JV48iCgWggG7yn//zf/8r8g+BvzvxFGkO0kmIhF8OGdEuf2tGOA2tf5bfccY5/o54vXzWgPwu4n1+5wTH+5PEN4GzvwbwzcuRn535+iRwLue4LuCAHHAn/wbwl4A/K6E/IPwB4h8En5AKCRCAABAEgXFI828gAAAUQAjx7wgIIDGvoPnd+T+BjCsp/43IeB1vx9Gv5AAUhuwHb15zfl953yIAsFF4CCiEUCn/neA/HPa7AU8HajfaAHjc0n4kQFR/zwkE4/sBAsFhwhUBpoF5VXKBZp6vx08gNNx83v/NvHoDWPO+vJr0EPEw+dPBF8liiZWnJy1vtIPSr6YBhGBgvNcFoLvXC3gdF30ynulN8t3rV6MTmNY/52I8+y2r5U+eBL6qyYvA4rRCoRhQBQ9Tk+sOwvLWHNPrpnmzpNLIoLwl9a6GLwTYvL4ZzwBTn4xez0uMNxCNug+B5RcoFEKFQKmUp28FwCAQDoN1ELZb6zdPQEIPbSMgMQyVBgir9/tP9M92IJaw4E73OJhHeLZBeQ6DGyOhds8HMISY+aUHWtpvECzzVjX5muIgFAB+AcETnEn5Hg5B+2CI1L2eCVHTy28MuCRGfTq4e35UCgYIJzgzPbTRfjUeEmwJV1NYWos8KC6CSbnueY/IzneasaRJKBMjj3cgCEi6MCL+hnwP8r0o5LWH98k0pnu+ez09v1F/xnxbgJuUDxCKwvMFQlG4tJoaqKjjur+tzAEIKByQLQxIZJUX1MgDe04Y1QF8Y0LE+/Raf+2rYduh1AvYqb96Xup3DKa3i8LweB1AVJMPqgiWhT5TtHU3WwZFsEOa+UGdDYqYoybiFEdOgGZC/BQHb7E/Mj1H7J9X2l/jfrnSMH54XagC6gBBqOYNIkEYXAJos1S5MrsrOdDvtCsEg2UyNPUcQEiCJwtMhHcQxr1dauAl5rWWtMXLJ5czMBjgS7LrAPQkV5SGYhivOKszoMVND90n+FWH9TxpIyYgS3rIB3PcATPBlYAwhZQuIbEn/j3hXY3nTHCr0efyuafpWrJ9ZPputPIAjmRA7YwwNUAW9KUtxl/90w3PT7oGkAV4irqhTDSS4CMEtEhq3V35Te2t9D55PTQFELvzNESapXdLGn8M44UjQSidAUWROhwE5CAtsjaDWqBA6wlMIQ9nZcRIB26wsBwS4AoPmJjnzoR3Ubwmva76Zp3Pxmbx/ox5DON7P2IJQN2M1mb8xoDinsmrl8EICMJAlHjtGoqGi/HrWRaZNTyQuWE1fFy3h8Ml/q+Zv8f9hQGdGZ0t1Cx11hNbHkcC8PAFAGCAkyFwArJIWnlzw/MUyIKueRm6ON5v5+y2FNWge1xSJsLF+1pk4eRVKNBF329GZ/bfS90M0/57BTPeD4+W75Dw6Axw4UAPgSyD1RvEkMOSgYyqHzqwpNGWYBhoQvMAhV7QLLqmGctEGV6dYIww6O1xJqthPPbEt/X05Kj/vpTerlxMs8StBofnMd/Hd3gsYmhUgRBDDiqM1WCAgSxwCo0JCMPM3lZ1BiAZIIVCNPcQ1gkE0UuqNjm0qr+1sRkgZAUQJtCWcW9YKO8TgEcC8FhCoYdBlVCTwHsIdDEDTzb0Q6CFLG5eQAqtK5tx++ViUCg6F2HykQyZR1iizAyT+r3URaa3oe+FpflKEHuNPxaP78ZP70/juwbIHFAUlTSM5zBcGQoRDoK7oVEgHZ5MiPI2j/e2NjW9E40OY/QKvRwO46FN30/6a9J+SXQclJ+GrR5/LolvZUBdlWBeK3RAmuBZTQkb+cBoERosw/jWDb8FQFtm73PDMpJjgN1bxz6qWrP+LHNJ+d7MLDE/E930+PPKAiES32o8pJJJMJuhc4ykqK4DLaPUllBwGEuC4XA0kBUGB+VJa02FhCidnsONRqIYl1DAiGrPCtD2AeYw3oaLFs8vhj59P29lTxOAkjK4dL0AoRoCAInZ/PbDUhjbrApDKOW8gI6mAloCgTrZIG3qrpFoTpxGmAyUx4BqZH+Nhsbn5CZudvO8Ty+n11cABu19SXiC6lCHEf8miEMHcDU8elPRoGyTKcv+vo9JGtwnG4IFNZkQB+AAHWAksdaA04DigDlhxjEW7So+okJDLZbu+S5bXTgSgG74Svvn8Lx0LH1AZ40JKpBMoegpqZJtm011zcYEIcLCsqa3nBQZXAVOg1nJytBgKDC1ZIOPrCKEuGotanoPBfo2CIigy+lSTcUd8tZRL4Y+3fW8xP6gu/dSJxRJRWIRZAv1x0iMPAcAzFAgh2gd4TDCIi4DokVoeAFZYGwwVBgbyBaMwDG6e6ejmXB6eLJ4qjFPVhhQPILIqSyqgkmqEg9JD/c0Xni6dzD0yL9Xn21vSc9nqZSF52GQGGAIgjYA+jRnY8IGQPTE3vOC+usSqtFPmBWwVdBqAMEGsEGtwc3RrOHhjsMdR3Mc5qhecbTgDoaSDOrXpPPDFwAu2f5wqY5EJ5Wlzps2r2uKseB8RQIwldnarfMtNLAkxz1BGgwF7pkUVWBeQR5AHu7fONsDTzvxZQe+7YGvduibNQCUoZLynCD12H1IevjwNh7p/cPX2q7hdctSF7ph0j3PUaEDDA0AAC7jKs5JxRsbEhB+qBQooEoAoBKh4AdgB9wPND3Q/IHTHzjbQycfcBygiiorGiOlGiI0LipPW6xrp3sfgixUH5J5mWYnAAFEhZ37aGYZ0XIbW01mbICsQHDK5/h/yZa6IiRIgOB6wP0pbw8AT5gOHX7gm1UNBZCBoPoEJ0uajmW4UWd8Dy/bUIpJ9WUiPIfEmt23sDLgMqe6zKuJHQwuy2V9UVPZUhsJN4tSxwLSABaIB4QD0AH4M41/6vAHXnzoxAFHEYI9KiKqiGOd44mo6OPtKY83w7Vascy6RwiwK7aVATerFTeDe97M8gcgnAdJ0AAawWKAWYJxgDpEf6LggUNPvNpTX3ii6akAqIpeVFSCQ4qaYmIXMbAcqaxrjauxvLtNXadvyiRI3C+B4X1Je15RY7BLKI1WApDttCHGaQXRTZqBVmA8wnh/6KEXvvTCqZeaPyE9BD9EHTBVGQpKqAZYhJqsL8EPCb8745PzLt03PjBgLqLdGT25NNQLQAfZB//xWuaQeQLQ1xkyWbKi6IGqBx7+G872wtlecH9J/gT8Cfoh4lAog6LIJYFoX6fWWFZf/M659D43MKyf7StvFfZ9A8AFqFvDNaTuPDfQHDCP1yVAiPexNmAwFFUWP1T9wdNfau03+PmCny/IX4C/AH8AeoAx50GgWINSMCjoNUqzEghxiXym0dtqDMfyBcA7BmgHgDfnYfRymAMWogelgXbGe3NYsiJiNdRj0YGKB9xfcP9/ePuNOl9Qe0ntBekJ6AnoIHjEDIcVYo3GmAWiSUzBvAAyd5pwZAUNEHKMyvDqJQf44vEbb0PvRjMNH8e5nWkNpM+FFycMFfKKggdcJ+Qn5afk39D5Dfg35F+UvhDS54gKwiMBqBCLAoQSKw80gcmMpTyPRm+EAbMU8FIF1vFW9zL8s8ffDO9Gn0BZgGCLvIDASzDIK8BKQ4sZtJqgRnmDdELthNq3oG8KDwghloRD4kGxSqx5LhQNYiE6CDCJyTnmAI25Vh2eVwciABgx7jcx7vvrjO/Pxp/zs+wDsuLkspgB7hB9WRbr8wMBckoOqUF+Sop9YI5H1xErCIijRPuOgs6CeJ9hwZREtDFfCiCISIJbzPtNgls8fkf5cgGgA9Sv0edejYiamAtlPMlxgzYWt6KIeqxCK87M1QGxxYEKWQKAEQ4QC4DC2GYTAGTS1JIX1EGZDOAdAFev+0hy11h/93z+27HHrd/MElo5NCGc4CnAYh9Fr15UGK8YmwoNUqN4dsGEhQURDpEgBeYsqYNAy3XuWTFAoobHdElw+uz1AcCvjB9ia1lH4/1+sPgtki3X0dedBBqr0ICTcomeLDhAJSNYJhAqBItiqlXY8wJpFA2jUyCRDPA9028ev0t2Nwyw5fu9mowmS8s6OC8t95JvzEm6YI2w775iq5zUdBDirBjHiQ1QDGgDiMgJUA+JJqmANEomLlUCIirK93uZG15fans38up9W+P9Qvtt78tieP986686ExrBbLdtHZftC+iMREmwiczdA6oJSonmK8YjDJCKFCAQJKPhJhcAMiav8W5+4/X2wXjNTT/bFjBejos+51J6Tf03SR8bC2JSp7y4+hjV5yieC/tUO5gg+ypgY0wHLfdDxBbQyAHQfcJb4/qT4db2JKrrUGU9bH9/3StoF6VpjRQFNfZLRd8lvm2pUCXkmkBEGEznjPV8AkYmCJcc8Iu4X4EZ3110g3Cz+e/GePC9T31jAHOvrnNIfPa9EMr9WH1rVrKBNfONR6ML78suEwwZwQAhGfD9g9C5yQH97/Td85eByTTa3j0vvneqvIQCE4hwNiGKJMVz6dm6wBYClLHNIjcqzr2mAUQBYRQGAJxlcFDlGvdXz/u98box3nkT/7x8/9q2L0zwfl9MJjCZ0JjbBCIvUMv6ca4+XzbbTiAKOQa67AAsITDof2HCGh6b1/FDsrNfGM93w+cEc4IQTcSYwZF9v6mkZR7TM7D6kEa5aS86A82Nt0agMKXw+aGtvTlvnv9k9NXwT/TnbeS8hYJpbt607lX2BpPAqZxBiRLjP/mezkGTYEWuO1luxH0LgSsDfNf0vcZf71yfgOB94nubQON9BvGWDxYg4n6ICHomAvPcB0Oy1GGxyhnSuxCaeWDpBfxdBG3t7zIs0SXL48779gMgH+aN2xMV+MF4pL7ve1D2vVfhdlEoseEFCmGkPhqJKTXkqJ8Nzs+w/Ojq+TvD8cF4cB9Fvu8UvDxaopvHTYT5hMY6pMkcMHfGz7xAzVIppX4wRPzHLqibKuDvLfGnafFPca4bIQTeZ3/+ohoI7wmSuaLqWpkQUEoCCnO3LvN5LAoSVAiKVNcBQ8n5MgG6lDlqz+D/9YH7B4M+hsH6aEl/cElzk3Vngq9MiMaB8vXBNkI9T4wNfLn2HCKrRnnTu/G4ZHtcKPzJyx8zPi/Jj/tizOiAl06YV0DW89pA9e2qAGgkXPmcBpQKNWOg64RQgzLWNy3/pu4+GH4b578A4m65gR/C4Uej8f63Mdf0XMH2uSt/7DKLnR+5MBwbJDY9f+f1N8N/MtjuS58+iB/8YPz2lJXmw1p3gIx5y5htMrZqet+z1bmlbnhfv6pjDrBNhu828/+HSu/WcH5cYXtbtbrSHz8ZvxidK1RRiQDl/tQYArtmYrD1GTVUUDFSiXFLe9/Mf5ngvLHALsmO+/Zv8f1xkB+WHPdn6+6evFxCoD+spPU5xHU/vjT289OzlUbTGCvRK+hfAL4A/J2/3za9fm1p8VN542XkxQ+1jv/BIuwnEBY2CPuDiAsbOPvznCAZ4hEOtLCXXwC/KqC/AJTkRwuJdK3zV49eMvobCHifDXy09RffGY/p8WYNc2HE+O4CnPZMHgTxRuBvgP+S+FcF8eeyLvbd9xrcNOv71hndKMJr2OiaAD9Q/rq0TSxU5iXWuT/KDu6PH6yO53rxAYgD+gLwLwJ//hszbBgU9Kg15wAAAABJRU5ErkJggg==";
+
+type FaviconSource = "default" | "fallback" | "profile";
+
+function buildFaviconSvg(avatarDataUrl: string | null): string {
+  const { avatar, canvasSize, gradient } = FAVICON_LAYOUT;
+  const avatarCenterX = avatar.x + avatar.size / 2;
+  const avatarCenterY = avatar.y + avatar.size / 2;
+  const avatarMarkup =
+    avatarDataUrl === null
+      ? ""
+      : `<circle cx="${avatarCenterX}" cy="${avatarCenterY}" r="${avatar.size / 2}" fill="#fff"/><image id="avatar" href="${escapeXmlAttribute(avatarDataUrl)}" x="${avatar.x}" y="${avatar.y}" width="${avatar.size}" height="${avatar.size}" preserveAspectRatio="xMidYMid slice" clip-path="url(#avatar-clip)"/>`;
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${canvasSize}" height="${canvasSize}" viewBox="0 0 ${canvasSize} ${canvasSize}">`,
+    "<defs>",
+    `<clipPath id="gradient-clip"><rect x="${gradient.x}" y="${gradient.y}" width="${gradient.size}" height="${gradient.size}" rx="${gradient.radius}"/></clipPath>`,
+    `<clipPath id="avatar-clip"><circle cx="${avatarCenterX}" cy="${avatarCenterY}" r="${avatar.size / 2}"/></clipPath>`,
+    "</defs>",
+    `<image id="gradient" href="${GRADIENT_PNG_DATA_URL}" x="${gradient.x}" y="${gradient.y}" width="${gradient.size}" height="${gradient.size}" preserveAspectRatio="xMidYMid slice" clip-path="url(#gradient-clip)"/>`,
+    avatarMarkup,
+    "</svg>",
+  ].join("");
+}
+
+async function responseImageDataUrl(response: Response): Promise<string | null> {
+  if (!response.ok) {
+    return null;
+  }
+
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (contentType === undefined || !SUPPORTED_AVATAR_TYPES.has(contentType)) {
+    return null;
+  }
+
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_AVATAR_BYTES) {
+    return null;
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.length === 0 || bytes.length > MAX_AVATAR_BYTES) {
+    return null;
+  }
+
+  return `data:${contentType};base64,${bytesToBase64(bytes)}`;
+}
+
+function faviconSvgResponse(svg: string, cacheControl: string, source: FaviconSource): Response {
+  return new Response(svg, {
+    headers: {
+      "cache-control": cacheControl,
+      "content-security-policy": "default-src 'none'; img-src data:",
+      "content-type": "image/svg+xml; charset=utf-8",
+      "x-favicon-source": source,
+    },
+  });
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+
+  return btoa(binary);
+}
+
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+export {
+  buildFaviconSvg,
+  DEFAULT_FAVICON_CACHE_CONTROL,
+  FAVICON_LAYOUT,
+  faviconSvgResponse,
+  PROFILE_FAVICON_CACHE_CONTROL,
+  responseImageDataUrl,
+};
+
+export type { FaviconSource };

--- a/apps/www/src/lib/favicon.test.ts
+++ b/apps/www/src/lib/favicon.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_FAVICON_URL, profileFaviconUrl } from "./favicon";
+import { buildFaviconSvg, FAVICON_LAYOUT, responseImageDataUrl } from "./favicon-svg";
+
+describe("favicon layout", () => {
+  it("centers the gradient and anchors the avatar at its center", () => {
+    const { avatar, canvasSize, gradient } = FAVICON_LAYOUT;
+
+    expect(avatar.x).toBe(gradient.x + gradient.size / 2);
+    expect(avatar.y).toBe(gradient.y + gradient.size / 2);
+    expect(gradient.x + gradient.size / 2).toBe(canvasSize / 2);
+    expect(gradient.y + gradient.size / 2).toBe(canvasSize / 2);
+    expect(gradient.size).toBe(40);
+    expect(gradient.radius).toBeGreaterThan(0);
+  });
+
+  it("uses the same rounded gradient geometry with and without a profile image", () => {
+    const defaultSvg = buildFaviconSvg(null);
+    const profileSvg = buildFaviconSvg("data:image/png;base64,YXZhdGFy");
+    const gradientTag = defaultSvg.match(/<image id="gradient"[^>]+>/)?.[0];
+
+    expect(gradientTag).toBeDefined();
+    expect(profileSvg).toContain(gradientTag);
+    expect(defaultSvg).not.toContain('id="avatar"');
+    expect(profileSvg).toContain('id="avatar"');
+    expect(profileSvg).toContain('clip-path="url(#avatar-clip)"');
+  });
+});
+
+describe("favicon URLs", () => {
+  it("versions profile icons by avatar URL", () => {
+    const first = profileFaviconUrl({
+      avatarUrl: "https://avatars.example.com/one.png",
+      login: "alex test",
+    });
+    const second = profileFaviconUrl({
+      avatarUrl: "https://avatars.example.com/two.png",
+      login: "alex test",
+    });
+
+    expect(first).toMatch(/^\/favicon\/alex%20test\.svg\?v=[a-z0-9]+$/);
+    expect(second).not.toBe(first);
+  });
+
+  it("falls back to the default icon for profiles without avatars", () => {
+    expect(profileFaviconUrl({ avatarUrl: null, login: "alex" })).toBe(DEFAULT_FAVICON_URL);
+  });
+});
+
+describe("avatar embedding", () => {
+  it("embeds supported raster responses as data URLs", async () => {
+    const dataUrl = await responseImageDataUrl(
+      new Response(new Uint8Array([137, 80, 78, 71]), {
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    expect(dataUrl).toBe("data:image/png;base64,iVBORw==");
+  });
+
+  it("rejects unsupported image types", async () => {
+    const dataUrl = await responseImageDataUrl(
+      new Response("<svg/>", {
+        headers: { "content-type": "image/svg+xml" },
+      }),
+    );
+
+    expect(dataUrl).toBeNull();
+  });
+});

--- a/apps/www/src/lib/favicon.ts
+++ b/apps/www/src/lib/favicon.ts
@@ -1,4 +1,29 @@
 const DEFAULT_APPLE_TOUCH_ICON_URL = "/apple-touch-icon.png";
-const DEFAULT_FAVICON_URL = "/favicon.png";
+const DEFAULT_FAVICON_URL = "/favicon.svg";
 
-export { DEFAULT_APPLE_TOUCH_ICON_URL, DEFAULT_FAVICON_URL };
+interface FaviconProfile {
+  avatarUrl: string | null;
+  login: string;
+}
+
+function profileFaviconUrl(profile: FaviconProfile): string {
+  if (profile.avatarUrl === null) {
+    return DEFAULT_FAVICON_URL;
+  }
+
+  return `/favicon/${encodeURIComponent(profile.login)}.svg?v=${stableHash(profile.avatarUrl)}`;
+}
+
+function stableHash(value: string): string {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+
+  return (hash >>> 0).toString(36);
+}
+
+export { DEFAULT_APPLE_TOUCH_ICON_URL, DEFAULT_FAVICON_URL, profileFaviconUrl };
+
+export type { FaviconProfile };

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -17,12 +17,14 @@ import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as InternalRouteImport } from './routes/internal'
+import { Route as FaviconDotsvgRouteImport } from './routes/favicon[.]svg'
 import { Route as DesignRouteImport } from './routes/design'
 import { Route as UserRouteImport } from './routes/$user'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as OgChar123loginChar125DotpngRouteImport } from './routes/og/{$login}[.]png'
 import { Route as OgCardLoginRouteImport } from './routes/og-card/$login'
 import { Route as LoginCliRouteImport } from './routes/login_.cli'
+import { Route as FaviconChar123loginChar125DotsvgRouteImport } from './routes/favicon/{$login}[.]svg'
 
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
@@ -64,6 +66,11 @@ const InternalRoute = InternalRouteImport.update({
   path: '/internal',
   getParentRoute: () => rootRouteImport,
 } as any)
+const FaviconDotsvgRoute = FaviconDotsvgRouteImport.update({
+  id: '/favicon.svg',
+  path: '/favicon.svg',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DesignRoute = DesignRouteImport.update({
   id: '/design',
   path: '/design',
@@ -95,11 +102,18 @@ const LoginCliRoute = LoginCliRouteImport.update({
   path: '/login/cli',
   getParentRoute: () => rootRouteImport,
 } as any)
+const FaviconChar123loginChar125DotsvgRoute =
+  FaviconChar123loginChar125DotsvgRouteImport.update({
+    id: '/favicon/{$login}.svg',
+    path: '/favicon/{$login}.svg',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/design': typeof DesignRoute
+  '/favicon.svg': typeof FaviconDotsvgRoute
   '/internal': typeof InternalRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/login': typeof LoginRoute
@@ -108,6 +122,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRoute
   '/stats': typeof StatsRoute
   '/terms': typeof TermsRoute
+  '/favicon/{$login}.svg': typeof FaviconChar123loginChar125DotsvgRoute
   '/login/cli': typeof LoginCliRoute
   '/og-card/$login': typeof OgCardLoginRoute
   '/og/{$login}.png': typeof OgChar123loginChar125DotpngRoute
@@ -116,6 +131,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/design': typeof DesignRoute
+  '/favicon.svg': typeof FaviconDotsvgRoute
   '/internal': typeof InternalRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/login': typeof LoginRoute
@@ -124,6 +140,7 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsRoute
   '/stats': typeof StatsRoute
   '/terms': typeof TermsRoute
+  '/favicon/{$login}.svg': typeof FaviconChar123loginChar125DotsvgRoute
   '/login/cli': typeof LoginCliRoute
   '/og-card/$login': typeof OgCardLoginRoute
   '/og/{$login}.png': typeof OgChar123loginChar125DotpngRoute
@@ -133,6 +150,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/design': typeof DesignRoute
+  '/favicon.svg': typeof FaviconDotsvgRoute
   '/internal': typeof InternalRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/login': typeof LoginRoute
@@ -141,6 +159,7 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/stats': typeof StatsRoute
   '/terms': typeof TermsRoute
+  '/favicon/{$login}.svg': typeof FaviconChar123loginChar125DotsvgRoute
   '/login_/cli': typeof LoginCliRoute
   '/og-card/$login': typeof OgCardLoginRoute
   '/og/{$login}.png': typeof OgChar123loginChar125DotpngRoute
@@ -151,6 +170,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$user'
     | '/design'
+    | '/favicon.svg'
     | '/internal'
     | '/llms.txt'
     | '/login'
@@ -159,6 +179,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/stats'
     | '/terms'
+    | '/favicon/{$login}.svg'
     | '/login/cli'
     | '/og-card/$login'
     | '/og/{$login}.png'
@@ -167,6 +188,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$user'
     | '/design'
+    | '/favicon.svg'
     | '/internal'
     | '/llms.txt'
     | '/login'
@@ -175,6 +197,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/stats'
     | '/terms'
+    | '/favicon/{$login}.svg'
     | '/login/cli'
     | '/og-card/$login'
     | '/og/{$login}.png'
@@ -183,6 +206,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$user'
     | '/design'
+    | '/favicon.svg'
     | '/internal'
     | '/llms.txt'
     | '/login'
@@ -191,6 +215,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/stats'
     | '/terms'
+    | '/favicon/{$login}.svg'
     | '/login_/cli'
     | '/og-card/$login'
     | '/og/{$login}.png'
@@ -200,6 +225,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   UserRoute: typeof UserRoute
   DesignRoute: typeof DesignRoute
+  FaviconDotsvgRoute: typeof FaviconDotsvgRoute
   InternalRoute: typeof InternalRoute
   LlmsDottxtRoute: typeof LlmsDottxtRoute
   LoginRoute: typeof LoginRoute
@@ -208,6 +234,7 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRoute
   StatsRoute: typeof StatsRoute
   TermsRoute: typeof TermsRoute
+  FaviconChar123loginChar125DotsvgRoute: typeof FaviconChar123loginChar125DotsvgRoute
   LoginCliRoute: typeof LoginCliRoute
   OgCardLoginRoute: typeof OgCardLoginRoute
   OgChar123loginChar125DotpngRoute: typeof OgChar123loginChar125DotpngRoute
@@ -271,6 +298,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InternalRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/favicon.svg': {
+      id: '/favicon.svg'
+      path: '/favicon.svg'
+      fullPath: '/favicon.svg'
+      preLoaderRoute: typeof FaviconDotsvgRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/design': {
       id: '/design'
       path: '/design'
@@ -313,6 +347,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginCliRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/favicon/{$login}.svg': {
+      id: '/favicon/{$login}.svg'
+      path: '/favicon/{$login}.svg'
+      fullPath: '/favicon/{$login}.svg'
+      preLoaderRoute: typeof FaviconChar123loginChar125DotsvgRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -320,6 +361,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   UserRoute: UserRoute,
   DesignRoute: DesignRoute,
+  FaviconDotsvgRoute: FaviconDotsvgRoute,
   InternalRoute: InternalRoute,
   LlmsDottxtRoute: LlmsDottxtRoute,
   LoginRoute: LoginRoute,
@@ -328,6 +370,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRoute,
   StatsRoute: StatsRoute,
   TermsRoute: TermsRoute,
+  FaviconChar123loginChar125DotsvgRoute: FaviconChar123loginChar125DotsvgRoute,
   LoginCliRoute: LoginCliRoute,
   OgCardLoginRoute: OgCardLoginRoute,
   OgChar123loginChar125DotpngRoute: OgChar123loginChar125DotpngRoute,

--- a/apps/www/src/routes/$user.tsx
+++ b/apps/www/src/routes/$user.tsx
@@ -2,10 +2,15 @@ import { useMemo, useState } from "react";
 import { LinkSimple } from "@phosphor-icons/react/ssr";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
-import type { ProfileDailyResponse, ProfileDailyRow } from "@tokenmaxxing/api-contract";
+import type {
+  ProfileDailyResponse,
+  ProfileDailyRow,
+  ProfileResponse,
+} from "@tokenmaxxing/api-contract";
 
 type DailyRow = typeof ProfileDailyRow.Type;
 type DailyRange = (typeof ProfileDailyResponse.Type)["range"];
+type Profile = typeof ProfileResponse.Type;
 
 import { Heatmap } from "../components/charts/heatmap";
 import { MonthBars } from "../components/charts/month-bars";
@@ -24,6 +29,7 @@ import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { Code } from "../components/ui/code";
 import { isApiError } from "../lib/api";
+import { profileFaviconUrl } from "../lib/favicon";
 import { breadcrumbSchema, profilePageSchema } from "../lib/jsonld";
 import {
   OG_IMAGE_HEIGHT,
@@ -57,40 +63,50 @@ const Route = createFileRoute("/$user")({
       return {};
     }
 
-    const profile = loaderData.profile;
-    const title = profileOgTitle(profile);
-    const description = profileOgDescription(profile);
-    const image = profileOgImageUrl(profile);
-    const url = profileUrl(profile);
-
-    return {
-      meta: [
-        { title },
-        { name: "description", content: description },
-        { property: "og:title", content: title },
-        { property: "og:description", content: description },
-        { property: "og:type", content: "profile" },
-        { property: "og:url", content: url },
-        { property: "og:image", content: image },
-        { property: "og:image:width", content: String(OG_IMAGE_WIDTH) },
-        { property: "og:image:height", content: String(OG_IMAGE_HEIGHT) },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: image },
-      ],
-      scripts: [
-        {
-          type: "application/ld+json",
-          children: JSON.stringify(profilePageSchema(profile)),
-        },
-        {
-          type: "application/ld+json",
-          children: JSON.stringify(breadcrumbSchema(profile.user.login, url)),
-        },
-      ],
-    };
+    return profileHead(loaderData.profile);
   },
   component: ProfilePage,
 });
+
+function profileHead(profile: Profile) {
+  const title = profileOgTitle(profile);
+  const description = profileOgDescription(profile);
+  const image = profileOgImageUrl(profile);
+  const url = profileUrl(profile);
+
+  return {
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:type", content: "profile" },
+      { property: "og:url", content: url },
+      { property: "og:image", content: image },
+      { property: "og:image:width", content: String(OG_IMAGE_WIDTH) },
+      { property: "og:image:height", content: String(OG_IMAGE_HEIGHT) },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:image", content: image },
+    ],
+    links: [
+      {
+        rel: "icon",
+        href: profileFaviconUrl(profile.user),
+        type: "image/svg+xml",
+      },
+    ],
+    scripts: [
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(profilePageSchema(profile)),
+      },
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(breadcrumbSchema(profile.user.login, url)),
+      },
+    ],
+  };
+}
 
 const countFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
 
@@ -425,4 +441,4 @@ function calendarYearEnd(date: string): string {
   return `${date.slice(0, 4)}-12-31`;
 }
 
-export { deriveCharts, Route };
+export { deriveCharts, profileHead, Route };

--- a/apps/www/src/routes/-$user.test.ts
+++ b/apps/www/src/routes/-$user.test.ts
@@ -1,10 +1,37 @@
 import { describe, expect, it } from "vitest";
-import type { ProfileDailyResponse, ProfileDailyRow } from "@tokenmaxxing/api-contract";
+import type {
+  ProfileDailyResponse,
+  ProfileDailyRow,
+  ProfileResponse,
+} from "@tokenmaxxing/api-contract";
 
-import { deriveCharts } from "./$user";
+import { DEFAULT_FAVICON_URL } from "../lib/favicon";
+import { deriveCharts, profileHead } from "./$user";
 
 type DailyRange = (typeof ProfileDailyResponse.Type)["range"];
 type DailyRow = typeof ProfileDailyRow.Type;
+type Profile = typeof ProfileResponse.Type;
+
+describe("profile metadata", () => {
+  it("uses the composite profile favicon route when an avatar is available", () => {
+    const head = profileHead(profile("https://avatars.githubusercontent.com/u/89296201?v=4"));
+    const link = head.links[0];
+
+    expect(link).toMatchObject({
+      rel: "icon",
+      type: "image/svg+xml",
+    });
+    expect(link?.href).toMatch(/^\/favicon\/pondorasti\.svg\?v=[a-z0-9]+$/);
+  });
+
+  it("uses the centered default favicon when no avatar is available", () => {
+    expect(profileHead(profile(null)).links).toContainEqual({
+      rel: "icon",
+      href: DEFAULT_FAVICON_URL,
+      type: "image/svg+xml",
+    });
+  });
+});
 
 describe("deriveCharts", () => {
   it("fills sparse usage rows across the server-provided chart range", () => {
@@ -149,5 +176,32 @@ function dailyRow({
     key,
     outputTokens: 0,
     totalTokens,
+  };
+}
+
+function profile(avatarUrl: string | null): Profile {
+  return {
+    stats: {
+      activeDays: 7,
+      avgSpendPerActiveDay: 17.64,
+      currentStreakDays: 3,
+      deviceCount: 2,
+      firstDate: "2026-01-01",
+      lastDate: "2026-06-21",
+      leaderboardRank: 7,
+      longestStreakDays: 12,
+      peakDay: { date: "2026-06-20", spendUsd: 42 },
+      sessionCount: 14,
+      sources: ["claude", "codex"],
+      topModel: { model: "claude-opus", spendUsd: 42 },
+      totalSpendUsd: 123.45,
+      totalTokens: 987_654,
+    },
+    user: {
+      avatarUrl,
+      id: "user_123",
+      login: "pondorasti",
+      name: null,
+    },
   };
 }

--- a/apps/www/src/routes/-favicon.test.ts
+++ b/apps/www/src/routes/-favicon.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { handleDefaultFaviconRequest } from "./favicon[.]svg";
+import { makeProfileFaviconHandler } from "./favicon/{$login}[.]svg";
+
+describe("default favicon route", () => {
+  it("returns the rounded gradient on a transparent SVG canvas", async () => {
+    const response = handleDefaultFaviconRequest();
+    const svg = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/svg+xml; charset=utf-8");
+    expect(response.headers.get("x-favicon-source")).toBe("default");
+    expect(svg).toContain('viewBox="0 0 64 64"');
+    expect(svg).toContain('id="gradient"');
+    expect(svg).not.toContain('id="avatar"');
+  });
+});
+
+describe("profile favicon route", () => {
+  it("embeds the profile image into the composite SVG", async () => {
+    const fetchAvatar = vi.fn(
+      async () =>
+        new Response(new Uint8Array([137, 80, 78, 71]), {
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    const handler = makeProfileFaviconHandler({
+      fetchAvatar,
+      loadProfile: async () => ({
+        avatarUrl: "https://avatars.example.com/pondorasti.png",
+        login: "pondorasti",
+      }),
+    });
+    const response = await handler(routeContext("pondorasti"));
+    const svg = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-favicon-source")).toBe("profile");
+    expect(fetchAvatar).toHaveBeenCalledWith("https://avatars.example.com/pondorasti.png");
+    expect(svg).toContain('id="avatar"');
+    expect(svg).toContain("data:image/png;base64,iVBORw==");
+  });
+
+  it("keeps the gradient fallback when the avatar cannot be loaded", async () => {
+    const handler = makeProfileFaviconHandler({
+      fetchAvatar: async () => new Response("unavailable", { status: 503 }),
+      loadProfile: async () => ({
+        avatarUrl: "https://avatars.example.com/pondorasti.png",
+        login: "pondorasti",
+      }),
+    });
+    const response = await handler(routeContext("pondorasti"));
+    const svg = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-favicon-source")).toBe("fallback");
+    expect(svg).toContain('id="gradient"');
+    expect(svg).not.toContain('id="avatar"');
+  });
+
+  it("returns not found for an unknown profile", async () => {
+    const handler = makeProfileFaviconHandler({
+      fetchAvatar: async () => new Response(),
+      loadProfile: async () => null,
+    });
+
+    expect((await handler(routeContext("missing"))).status).toBe(404);
+  });
+});
+
+function routeContext(login: string) {
+  return {
+    params: { login },
+    request: new Request(`https://tokenmaxxing.sh/favicon/${login}.svg`),
+  };
+}

--- a/apps/www/src/routes/-root.test.ts
+++ b/apps/www/src/routes/-root.test.ts
@@ -7,7 +7,7 @@ describe("root metadata", () => {
   it("uses local 851 Labs gradient icons", () => {
     const head = rootHead();
 
-    expect(linkHref(head.links, "icon")).toBe("/favicon.png");
+    expect(linkHref(head.links, "icon")).toBe("/favicon.svg");
     expect(linkHref(head.links, "apple-touch-icon")).toBe("/apple-touch-icon.png");
   });
 

--- a/apps/www/src/routes/__root.tsx
+++ b/apps/www/src/routes/__root.tsx
@@ -46,7 +46,7 @@ function rootHead() {
     ],
     links: [
       { rel: "apple-touch-icon", href: DEFAULT_APPLE_TOUCH_ICON_URL },
-      { rel: "icon", href: DEFAULT_FAVICON_URL },
+      { rel: "icon", href: DEFAULT_FAVICON_URL, type: "image/svg+xml" },
       { rel: "stylesheet", href: styles },
     ],
     scripts: [

--- a/apps/www/src/routes/favicon/{$login}[.]svg.tsx
+++ b/apps/www/src/routes/favicon/{$login}[.]svg.tsx
@@ -1,0 +1,114 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { resolveApiUrl } from "../../lib/config";
+import {
+  buildFaviconSvg,
+  faviconSvgResponse,
+  PROFILE_FAVICON_CACHE_CONTROL,
+  responseImageDataUrl,
+} from "../../lib/favicon-svg";
+
+interface ProfileFaviconRouteContext {
+  params: {
+    login: string;
+  };
+  request: Request;
+}
+
+interface ProfileFaviconData {
+  avatarUrl: string | null;
+  login: string;
+}
+
+interface ProfileFaviconRouteDeps {
+  fetchAvatar(url: string): Promise<Response>;
+  loadProfile(login: string): Promise<ProfileFaviconData | null>;
+}
+
+const defaultDeps: ProfileFaviconRouteDeps = {
+  fetchAvatar: (url) =>
+    fetch(url, {
+      headers: {
+        accept: "image/avif,image/webp,image/png,image/jpeg,image/gif",
+      },
+    }),
+  loadProfile: loadProfileFaviconData,
+};
+
+function makeProfileFaviconHandler(deps: ProfileFaviconRouteDeps = defaultDeps) {
+  return async function handleProfileFaviconRequest({
+    params,
+  }: ProfileFaviconRouteContext): Promise<Response> {
+    const profile = await deps.loadProfile(params.login);
+    if (profile === null) {
+      return new Response("Not found", {
+        headers: {
+          "cache-control": "public, max-age=60",
+        },
+        status: 404,
+      });
+    }
+
+    let avatarDataUrl: string | null = null;
+    if (profile.avatarUrl !== null && isSafeAvatarUrl(profile.avatarUrl)) {
+      try {
+        avatarDataUrl = await responseImageDataUrl(await deps.fetchAvatar(profile.avatarUrl));
+      } catch {
+        avatarDataUrl = null;
+      }
+    }
+
+    return faviconSvgResponse(
+      buildFaviconSvg(avatarDataUrl),
+      PROFILE_FAVICON_CACHE_CONTROL,
+      avatarDataUrl === null ? "fallback" : "profile",
+    );
+  };
+}
+
+async function loadProfileFaviconData(login: string): Promise<ProfileFaviconData | null> {
+  const apiUrl = resolveApiUrl().replace(/\/$/, "");
+  const response = await fetch(`${apiUrl}/profiles/${encodeURIComponent(login)}`);
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to load favicon profile ${login}: ${response.status}`);
+  }
+
+  const payload = (await response.json()) as {
+    user: {
+      avatarUrl: string | null;
+      login: string;
+    };
+  };
+  return payload.user;
+}
+
+function isSafeAvatarUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+const handleProfileFaviconRequest = makeProfileFaviconHandler();
+
+const Route = createFileRoute("/favicon/{$login}.svg")({
+  server: {
+    handlers: {
+      GET: handleProfileFaviconRequest,
+    },
+  },
+});
+
+export {
+  handleProfileFaviconRequest,
+  isSafeAvatarUrl,
+  loadProfileFaviconData,
+  makeProfileFaviconHandler,
+  Route,
+};
+
+export type { ProfileFaviconData, ProfileFaviconRouteContext, ProfileFaviconRouteDeps };

--- a/apps/www/src/routes/favicon[.]svg.tsx
+++ b/apps/www/src/routes/favicon[.]svg.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import {
+  buildFaviconSvg,
+  DEFAULT_FAVICON_CACHE_CONTROL,
+  faviconSvgResponse,
+} from "../lib/favicon-svg";
+
+function handleDefaultFaviconRequest(): Response {
+  return faviconSvgResponse(buildFaviconSvg(null), DEFAULT_FAVICON_CACHE_CONTROL, "default");
+}
+
+const Route = createFileRoute("/favicon.svg")({
+  server: {
+    handlers: {
+      GET: handleDefaultFaviconRequest,
+    },
+  },
+});
+
+export { handleDefaultFaviconRequest, Route };


### PR DESCRIPTION
## Summary

- keep the existing TokenMaxxing gradient centered at the same 40×40 size on a transparent 64×64 canvas for every page
- round the gradient corners consistently, including the default `/` favicon
- generate profile favicons that overlay the page user's circular avatar from the gradient center toward the bottom-right
- serve self-contained SVG favicons with cache headers, avatar URL versioning, safe image validation, and a gradient-only fallback

The profile treatment preserves the default favicon's gradient position and scale, so moving between `/` and `/{gitusername}` does not make the gradient zoom or jump.

## Geometry

- canvas: 64×64, transparent
- gradient: 40×40 at (12, 12), radius 5, centered at (32, 32)
- profile image: 24×24 circle at (32, 32), extending into the bottom-right quadrant

## Validation

- `bun run fmt`
- type-aware lint (passes with one pre-existing warning in `apps/api/src/leaderboard/service.test.ts`)
- `bun run --filter @tokenmaxxing/www test` — 33 tests passed
- `bun run --filter @tokenmaxxing/www typecheck`
- `bun run --filter @tokenmaxxing/www build`
- full workspace typecheck
- production-preview QA on `/`, `/jacethings`, and both direct SVG favicon routes

The full monorepo test command still encounters unrelated environment-specific failures in the API's experimental Node SQLite adapter and CLI runtime-detection tests; the changed web package test suite passes in full.

Ready for review and merge.